### PR TITLE
docs(orchestration): update Career Playbook handoff after PR 35

### DIFF
--- a/.codex/handoff.md
+++ b/.codex/handoff.md
@@ -1,16 +1,17 @@
 # Orchestrator Handoff
 
 Updated: 2026-05-20
-Current working branch: `codex/career-playbook-generation-status`
-Current PR: #35 `codex/career-playbook-generation-status` -> `develop`
+Current working branch: `develop`
+Current PR: none for the current handoff update
 
 ## Current State
 
 - This repository is a single-repo pnpm monorepo with `packages/web`, `packages/course-gen-platform`, and `packages/shared-types`.
 - `.codex/orchestrator.toml` is the machine-readable contract; `.codex/handoff.md` is current-state only; `.codex/project-index.md` is the navigation map.
 - Delivery truth remains unchanged: `/push-dev` drives Dev through `develop`, `/push` is release/version flow, and `/deploy` targets staging through `master`.
-- Career Playbook PR #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, and #34 have landed in `develop`.
-- PR #35 adds Career Playbook worker completion persistence plus polling generation-status transport on top of the already landed viewer, landing, library/share, and PDF export work.
+- Career Playbook PR #24 through #35 have landed in `develop`.
+- PR #35 merged on 2026-05-20 as `f79b25ff`; it added Career Playbook worker completion persistence plus polling generation-status transport on top of viewer, landing, library/share, and PDF export work.
+- PR #36 is open as a draft (`codex/career-playbook-jd-bridge`) and still targets the old stacked base `codex/career-playbook-generation-status`; it should be retargeted to `develop` only after review and verification.
 - No billing or payment scope is part of the Career Playbook MVP work in this branch.
 
 ## Latest Relevant Stage
@@ -25,19 +26,19 @@ Current PR: #35 `codex/career-playbook-generation-status` -> `develop`
 
 ## Next recommended
 
-Next stage id: `mc2-db696.11.7.7.9`
-Recommended action: finish PR #35 readiness against `develop`, preserving landed PDF/viewer/landing/library-share behavior while adding protected generation status transport. Do not add billing/payment scope; merge only after review fixes, local verification, and acceptable GitHub CI/no-check status.
+Next stage id: `mc2-db696.11.8`
+Recommended action: continue PR #36 readiness for the JD→Course bridge. Fetch latest `origin/develop`, inspect PR #36, resolve any base drift from the old stacked branch, retarget to `develop` only when the branch is reviewed and locally verified, and keep billing/payment out of MVP scope.
 
-After PR #35 lands, continue the dependent stack: PR #36 JD/course bridge, then PR #37 E2E smoke.
+After PR #36 lands, continue PR #37 / Phase 11 smoke and verification work, including open live-staging and cost/load evidence tasks.
 
 ## Starter prompt for next orchestrator
 
 ```text
-Use $orchestrator-stage to continue Career Playbook PR-stack readiness. Read AGENTS.md, .codex/orchestrator.toml, .codex/handoff.md, docs/plans/quiet-waddling-starfish.md, and docs/plans/career-playbook/* first. Use Beads as source of truth. PR #24-#34 have landed in develop; continue PR #35 generation status transport readiness against develop, verify worker completion/polling status behavior, and do not merge until CI is green or explicitly absent with local verification.
+Use $orchestrator-stage to continue Career Playbook delivery. Read AGENTS.md, .codex/orchestrator.toml, .codex/handoff.md, docs/plans/quiet-waddling-starfish.md, and docs/plans/career-playbook/* first. Use Beads as source of truth. PR #24-#35 have landed in develop; next Beads task is mc2-db696.11.8 for PR #36 JD→Course bridge readiness. Inspect PR #36, retarget from the old stacked base to develop only after review and local verification, and do not add billing/payment scope.
 ```
 
 ## Explicit defers
 
 - Real Supabase RLS/staging smoke and authenticated browser e2e share/PDF/worker flow remain tracked under `mc2-db696.11` unless credentials are available.
 - SSE/subscription status streaming remains deferred; PR #35 intentionally uses polling over the existing tRPC/httpBatchLink transport.
-- JD/course bridge remains tracked as `mc2-db696.9` and PR #36.
+- PR #36 JD/course bridge delivery readiness is tracked as `mc2-db696.11.8`; implementation task `mc2-db696.9` is closed but its draft PR is not yet landed.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -245,6 +245,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Build shared packages
         run: |
           pnpm --filter @megacampus/shared-types build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -246,7 +246,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm --filter @megacampus/course-gen-platform exec playwright install --with-deps chromium
 
       - name: Build shared packages
         run: |


### PR DESCRIPTION
Updates .codex/handoff.md after PR #35 merged so the next orchestrator starts from PR #36 readiness on develop.\n\nVerification:\n- scripts/orchestration/run_process_verification.sh