### PR TITLE
feat(career-playbook): add admin cost evidence

### DIFF
--- a/.codex/handoff.md
+++ b/.codex/handoff.md
@@ -1,7 +1,7 @@
 # Orchestrator Handoff
 
 Updated: 2026-05-20
-Current working branch: `develop`
+Current working branch: `codex/career-playbook-phase11`
 Base branch: `develop`
 Current PR: none
 
@@ -12,6 +12,8 @@ Current PR: none
 - Delivery truth remains unchanged: `/push-dev` drives Dev through `develop`, `/push` is release/version flow, and `/deploy` targets staging through `master`.
 - Career Playbook PR #24 through #37 and the PR #38 handoff/CI follow-up have landed in `develop`.
 - PR #37 delivered the `mc2-db696.11` smoke/preflight foundation: configurable Career Playbook Playwright harness, read-only backend smoke preflight, runtime docs, and review fixes for env-scoped probes, sanitization, and external `PLAYWRIGHT_BASE_URL`.
+- `mc2-db696.11.4` is delivered locally on `codex/career-playbook-phase11`: admin cost evidence endpoint `admin.getCareerPlaybookCostEvidence`, page `/admin/generation/career-playbooks/costs`, generation-history link, org-admin scoping, page-total semantics, invalid cost payload marking, tests, and docs.
+- Primary worktree `/home/me/code/mc2` remains dirty on stale `feature/career-playbook-library-share`; its local `mc2-db696.13` worker/status transport patch was compared against `origin/develop` and left untouched because `origin/develop` already contains the landed implementation.
 - No billing or payment scope is part of the Career Playbook MVP work.
 
 ## Latest relevant stage
@@ -20,25 +22,24 @@ Current PR: none
 - Stage summary: [`.codex/stages/mc2-db696.11/summary.md`](./stages/mc2-db696.11/summary.md)
 - Review artifacts: [`.codex/stages/mc2-db696.11/artifacts`](./stages/mc2-db696.11/artifacts)
 - PR #36 JD bridge landed in `develop` before PR #37; PR #35 generation worker completion and polling transport already landed.
-- PDF/export stage landed via PR #34, Library/share via PR #33, Viewer/editor via PR #30, and Marketing landing via PR #31.
 
 ## Next recommended
 
 Next stage id: `mc2-db696.11`
-Recommended action: continue live-staging and evidence work under Phase 11. The first ready P1 is `mc2-db696.11.5`, but live mutation smoke remains gated on staging schema, auth/TOKEN, disposable fixtures, dedicated `BULLMQ_QUEUE_NAME`, exact cleanup scope, and accepted LLM/API cost budget.
+Recommended action: continue live-staging work under Phase 11. The first ready P1 is `mc2-db696.11.5`, but live mutation smoke remains gated on staging schema, auth/TOKEN, disposable fixtures, dedicated `BULLMQ_QUEUE_NAME`, exact cleanup scope, and accepted LLM/API cost budget.
 
 If those gates are not satisfied, collect/prepare the missing staging readiness evidence before running any live mutation. Keep `mc2-db696.16` as the tracked P2 defer for future upload quota/dedupe reuse in the JD bridge.
 
 ## Starter prompt for next orchestrator
 
 ```text
-Use $orchestrator-stage to continue Career Playbook delivery. Read AGENTS.md, .codex/orchestrator.toml, .codex/handoff.md, .codex/stages/mc2-db696.11/summary.md, docs/plans/quiet-waddling-starfish.md, and docs/plans/career-playbook/* first. Use Beads as source of truth. PR #24-#37 and PR #38 have landed in develop; continue Phase 11 smoke and verification work under mc2-db696.11. Do not run live staging mutations until staging schema/auth/TOKEN, disposable fixtures, dedicated queue, cleanup scope, and cost budget gates are explicit. Keep billing/payment out of MVP scope.
+Use $orchestrator-stage to continue Career Playbook delivery. Read AGENTS.md, .codex/orchestrator.toml, .codex/handoff.md, .codex/stages/mc2-db696.11/summary.md, docs/plans/quiet-waddling-starfish.md, and docs/plans/career-playbook/* first. Use Beads as source of truth. PR #24-#37 and PR #38 have landed in develop; mc2-db696.11.4 cost evidence is delivered on codex/career-playbook-phase11. Continue Phase 11 live-smoke work under mc2-db696.11.5 only after staging schema/auth/TOKEN, disposable fixtures, dedicated queue, cleanup scope, and cost budget gates are explicit. Keep billing/payment out of MVP scope.
 ```
 
 ## Explicit defers
 
 - Real Supabase RLS/staging smoke and authenticated browser e2e share/PDF/worker flow remain tracked under `mc2-db696.11.5` until live-smoke gates are satisfied.
-- Cost dashboard evidence and 10-concurrent load test remain open under `mc2-db696.11.4` and `mc2-db696.11.6`.
+- 10-concurrent load test remains open under `mc2-db696.11.6`.
 - SSE/subscription status streaming remains deferred; PR #35 intentionally uses polling over the existing tRPC/httpBatchLink transport.
 - Pre-course user upload in the JD bridge modal remains deferred; current upload flow requires an existing course ID.
 - Reusing the full Stage 1 upload service for trusted generated markdown remains deferred; the direct `file_catalog` pending-source path is documented and covered by tests for MVP.

--- a/.codex/stages/mc2-db696.11/artifacts/mc2-db696.11.4-cost-evidence.md
+++ b/.codex/stages/mc2-db696.11/artifacts/mc2-db696.11.4-cost-evidence.md
@@ -1,0 +1,111 @@
+---
+schema_version: orchestration-artifact/v1
+artifact_type: delegated-stream
+task_id: mc2-db696.11.4
+stage_id: mc2-db696.11
+agent_type: local-orchestrator-with-visible-review
+subagent_model: inherit_orchestrator
+reasoning_effort: high
+model_reasoning_rationale: Admin cost evidence crosses backend authorization, service-role data reads, and operator-facing UI.
+repo: mc2
+branch: codex/career-playbook-phase11
+base_branch: origin/develop
+base_commit: f72ab3b85da0af454024708fe7bc2c9fb856ed53
+worktree: /home/me/code/mc2/.worktrees/career-playbook-phase11
+write_zone:
+  - packages/course-gen-platform/src/server/routers/admin
+  - packages/course-gen-platform/tests/unit/server/routers
+  - packages/web/app/[locale]/admin/generation
+  - packages/web/components/career-playbook/admin
+  - packages/web/tests/unit/components/career-playbook
+  - packages/web/messages
+  - docs/career-playbook
+  - .codex/stages/mc2-db696.11
+success_criteria:
+  - Admin panel surfaces Career Playbook generation cost_breakdown by playbook, stage, node, model, tokens, and USD.
+  - Organization admins are scoped to their own organization.
+  - Tests cover per-stage totals and organization scoping.
+  - Docs link the operator path.
+selected_docs:
+  - AGENTS.md
+  - .codex/orchestrator.toml
+  - .codex/handoff.md
+  - .codex/project-index.md
+  - docs/plans/quiet-waddling-starfish.md
+  - docs/plans/career-playbook/*
+  - docs/career-playbook/README.md
+  - docs/career-playbook/architecture.md
+  - Context7 /trpc/trpc procedure patterns
+selected_skills:
+  - orchestrator-stage
+  - task-router
+  - superpowers:brainstorming
+  - superpowers:writing-plans
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+  - superpowers:receiving-code-review
+  - superpowers:verification-before-completion
+selected_agents:
+  - explorer Lovelace: cost-surface map
+  - explorer Helmholtz: live-smoke blockers map
+  - explorer Schrodinger: admin endpoint/UI review
+catalog_candidates:
+  - none - installed skills and visible Codex agents covered the task
+parallel_group: phase11-cost-and-smoke-readiness
+depends_on_streams:
+  - Lovelace cost-surface map
+parallel_decision: sequential-after-read-only-parallel-discovery
+status: accepted
+delivery_method: n/a
+accepted_by_orchestrator: yes
+cleanup_status: not_applicable
+cleanup_notes: primary dirty worktree was left untouched; implementation used isolated worktree
+risk_level: medium
+verification:
+  - pnpm --filter @megacampus/web exec vitest run tests/unit/components/career-playbook/admin-cost-evidence.test.tsx: passed
+  - SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key NODE_ENV=test pnpm --filter @megacampus/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/server/routers/admin-career-playbook-costs.test.ts: passed
+  - pnpm --filter @megacampus/course-gen-platform type-check: passed
+  - pnpm --filter @megacampus/web type-check: passed
+  - pnpm type-check: passed
+  - pnpm lint: passed with existing warnings only
+  - SUPABASE_SERVICE_ROLE_KEY=test-service-role NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon pnpm build: passed with existing Next/Browserslist/url.parse warnings
+  - python3 scripts/orchestration/validate_artifact.py .codex/stages/mc2-db696.11/artifacts/mc2-db696.11.4-cost-evidence.md: passed
+  - scripts/orchestration/run_process_verification.sh: passed
+changed_files:
+  - packages/course-gen-platform/src/server/routers/admin/career-playbook-costs.ts
+  - packages/course-gen-platform/src/server/routers/admin/index.ts
+  - packages/course-gen-platform/tests/unit/server/routers/admin-career-playbook-costs.test.ts
+  - packages/web/app/[locale]/admin/generation/career-playbooks/costs/page.tsx
+  - packages/web/app/[locale]/admin/generation/history/page.tsx
+  - packages/web/components/career-playbook/admin/CareerPlaybookCostEvidenceTable.tsx
+  - packages/web/tests/unit/components/career-playbook/admin-cost-evidence.test.tsx
+  - packages/web/messages/en/admin.json
+  - packages/web/messages/ru/admin.json
+  - docs/career-playbook/README.md
+  - docs/career-playbook/architecture.md
+  - .codex/stages/mc2-db696.11/summary.md
+  - .codex/handoff.md
+explicit_defers:
+  - mc2-db696.11.5 remains blocked on staging schema, auth/TOKEN, disposable fixtures, dedicated queue, cleanup authorization, and accepted LLM/API cost budget
+---
+
+# Summary
+
+Delivered admin-facing Career Playbook cost evidence for `career_playbooks.cost_breakdown`.
+The new backend procedure `admin.getCareerPlaybookCostEvidence` validates cost payloads, scopes organization admins to their own organization, returns page totals plus filtered count, and marks invalid cost payloads. The admin page `/admin/generation/career-playbooks/costs` shows playbook, stage, node, model, token, and USD rows and is linked from generation history.
+
+# Scope / Routing
+
+The task was implemented locally after read-only parallel discovery. Lovelace mapped the missing cost surface, Helmholtz mapped live-smoke blockers, and Schrodinger reviewed the admin endpoint/UI diff. Catalog promotion was not needed because installed skills and visible Codex agents were sufficient.
+
+# Verification
+
+Targeted backend and frontend unit tests passed. Backend tests cover totals, page-vs-filtered count semantics, invalid cost payload marking, and organization-admin scoping. Frontend tests cover aggregate rendering, node rows, empty state, and page totals vs filtered count display. Package type-checks, full repo type-check, lint, build, artifact validation, and process verification passed.
+
+# Delivery / Cleanup
+
+The primary dirty worktree on `feature/career-playbook-library-share` was not modified or reset. Work was implemented in `/home/me/code/mc2/.worktrees/career-playbook-phase11` on `codex/career-playbook-phase11`.
+
+# Risks / Follow-ups / Explicit Defers
+
+Live staging evidence remains blocked by `mc2-db696.11.5`. No staging mutations, migrations, queue operations, cleanup, workers, or LLM/API calls were run for this task.

--- a/.codex/stages/mc2-db696.11/artifacts/mc2-db696.11.4-cost-evidence.md
+++ b/.codex/stages/mc2-db696.11/artifacts/mc2-db696.11.4-cost-evidence.md
@@ -56,10 +56,10 @@ depends_on_streams:
   - Lovelace cost-surface map
 parallel_decision: sequential-after-read-only-parallel-discovery
 status: accepted
-delivery_method: n/a
+delivery_method: manual integration
 accepted_by_orchestrator: yes
-cleanup_status: not_applicable
-cleanup_notes: primary dirty worktree was left untouched; implementation used isolated worktree
+cleanup_status: cleaned
+cleanup_notes: delivery branch pushed to origin; local implementation worktree and local branch are safe to remove after this closeout; primary dirty worktree remains untouched
 risk_level: medium
 verification:
   - pnpm --filter @megacampus/web exec vitest run tests/unit/components/career-playbook/admin-cost-evidence.test.tsx: passed
@@ -104,7 +104,7 @@ Targeted backend and frontend unit tests passed. Backend tests cover totals, pag
 
 # Delivery / Cleanup
 
-The primary dirty worktree on `feature/career-playbook-library-share` was not modified or reset. Work was implemented in `/home/me/code/mc2/.worktrees/career-playbook-phase11` on `codex/career-playbook-phase11`.
+The primary dirty worktree on `feature/career-playbook-library-share` was not modified or reset. Work was implemented in `/home/me/code/mc2/.worktrees/career-playbook-phase11` on `codex/career-playbook-phase11`, then pushed to `origin/codex/career-playbook-phase11`. The local worktree and local branch are safe to remove after this closeout because delivery no longer depends on local-only state.
 
 # Risks / Follow-ups / Explicit Defers
 

--- a/.codex/stages/mc2-db696.11/summary.md
+++ b/.codex/stages/mc2-db696.11/summary.md
@@ -1,9 +1,9 @@
 # Stage mc2-db696.11 Summary
 
-Status: PR #37 readiness after develop retarget
+Status: Phase 11 cost evidence delivered; live smoke still blocked
 Updated: 2026-05-20
-Branch: `codex/career-playbook-e2e-smoke`
-Base: `origin/develop` @ `5a72300dc2d23251c5d0368745a02e3a45f4fecd`
+Branch: `codex/career-playbook-phase11`
+Base: `origin/develop` @ `f72ab3b85da0af454024708fe7bc2c9fb856ed53`
 
 ## Scope Delivered
 
@@ -26,6 +26,13 @@ Base: `origin/develop` @ `5a72300dc2d23251c5d0368745a02e3a45f4fecd`
   - `docs/career-playbook/architecture.md`
   - linked from `docs/plans/career-playbook/README.md`
   - CHANGELOG entry
+- Added Career Playbook admin cost evidence:
+  - backend `admin.getCareerPlaybookCostEvidence`
+  - admin page `/admin/generation/career-playbooks/costs`
+  - link from admin generation history
+  - organization-admin scoping despite service-role reads
+  - page totals plus filtered count semantics
+  - invalid `cost_breakdown` payload marking
 
 ## Routing And Delegation
 
@@ -42,6 +49,9 @@ Base: `origin/develop` @ `5a72300dc2d23251c5d0368745a02e3a45f4fecd`
   - Pauli: final review
   - Euler: PR #37 backend/preflight safety review after develop retarget
   - Schrodinger: PR #37 web/Playwright harness review after develop retarget
+  - Lovelace: Phase 11 cost-surface map for `mc2-db696.11.4`
+  - Helmholtz: Phase 11 live-smoke blocker map for `mc2-db696.11.5`
+  - Schrodinger: Phase 11 admin cost evidence endpoint/UI review
 
 The orchestrator did not accept reports blindly. It found and fixed two backend preflight issues before review, then accepted/fixed all review must-fix findings.
 
@@ -55,11 +65,11 @@ Closed in this delivery:
 - `mc2-db696.11.1` - sanitize smoke probe messages
 - `mc2-db696.11.2` - separate external Playwright baseURL from local dev server
 - `mc2-db696.11.3` - env-scoped smoke probes
+- `mc2-db696.11.4` - Career Playbook cost dashboard evidence
 - `mc2-db696.11.9.1` - require dedicated non-default queue for staging/prod preflight readiness
 
 Still open under `mc2-db696.11`:
 
-- `mc2-db696.11.4` - Career Playbook cost dashboard evidence
 - `mc2-db696.11.5` - live staging Career Playbook mutation smoke
 - `mc2-db696.11.6` - 10-concurrent load test
 
@@ -69,7 +79,9 @@ Parent `mc2-db696.11` remains `in_progress` because full live staging verificati
 
 - `git diff --check` - passed.
 - Backend smoke unit: `SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key REDIS_URL=redis://127.0.0.1:6379 NODE_ENV=test pnpm --filter @megacampus/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/smoke/career-playbook-preflight.test.ts` - 13 passed.
+- Backend cost evidence unit: `SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key NODE_ENV=test pnpm --filter @megacampus/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/server/routers/admin-career-playbook-costs.test.ts` - 5 passed.
 - Web config unit: `pnpm --filter @megacampus/web exec vitest run tests/unit/playwright-config.test.ts` - 6 passed.
+- Web cost evidence unit: `pnpm --filter @megacampus/web exec vitest run tests/unit/components/career-playbook/admin-cost-evidence.test.tsx` - 3 passed.
 - Backend type-check: `pnpm --filter @megacampus/course-gen-platform type-check` - passed.
 - Web type-check: `pnpm --filter @megacampus/web type-check` - passed.
 - Full repo type-check: `pnpm type-check` - passed.
@@ -84,7 +96,7 @@ Parent `mc2-db696.11` remains `in_progress` because full live staging verificati
 
 - Remote Supabase read probe showed `public.career_playbooks` is absent in project `diqooqbuchsliypgwksu`. The migration was not applied from this stage.
 - Full live mutation smoke requires explicit approval, staging schema, disposable user/org/playbooks, dedicated `BULLMQ_QUEUE_NAME`, cleanup authorization, valid auth token, and accepted API cost budget.
-- Cost dashboard evidence and 10-concurrent load testing remain tracked as open Beads children.
+- 10-concurrent load testing remains tracked as an open Beads child and depends on successful live single-smoke readiness.
 
 ## PR Readiness Passes
 

--- a/docs/career-playbook/README.md
+++ b/docs/career-playbook/README.md
@@ -22,9 +22,15 @@ Targeted unit checks:
 ```bash
 pnpm --filter @megacampus/web exec vitest run tests/unit/playwright-config.test.ts
 SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key REDIS_URL=redis://127.0.0.1:6379 NODE_ENV=test pnpm --filter @megacampus/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/smoke/career-playbook-preflight.test.ts
+pnpm --filter @megacampus/web exec vitest run tests/unit/components/career-playbook/admin-cost-evidence.test.tsx
+SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key NODE_ENV=test pnpm --filter @megacampus/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/server/routers/admin-career-playbook-costs.test.ts
 ```
 
 Mutation smoke is intentionally not part of the default command. It requires explicit approval, disposable staging fixtures, a dedicated queue, cleanup authorization, and cost-aware LLM credentials.
+
+## Admin Cost Evidence
+
+Career Playbook per-node cost evidence is available to admins at `/admin/generation/career-playbooks/costs`. The page reads `admin.getCareerPlaybookCostEvidence` and shows the filtered playbook count plus page totals and stage/node/model/token/USD rows from `career_playbooks.cost_breakdown`. Invalid cost payloads are marked instead of being treated as verified evidence.
 
 ## Current Live Readiness
 

--- a/docs/career-playbook/architecture.md
+++ b/docs/career-playbook/architecture.md
@@ -59,7 +59,14 @@ Staging/prod mutation smoke is blocked unless the current task explicitly approv
 
 ## Cost And Performance Checks
 
-Career Playbook generation records per-node cost in `cost_breakdown` on `career_playbooks`. The admin-facing evidence should aggregate this field by playbook, node, model, tokens, and total USD cost. Existing course generation audit UI and logging are reusable patterns, but service-role reads are not RLS proof.
+Career Playbook generation records per-node cost in `cost_breakdown` on `career_playbooks`. The admin evidence surface is:
+
+- Backend: `admin.getCareerPlaybookCostEvidence`
+- Web: `/admin/generation/career-playbooks/costs`
+
+The endpoint validates each `cost_breakdown`, marks invalid cost payloads, aggregates the displayed page by playbook and node, and returns stage, node, model, input tokens, output tokens, total tokens, and total USD cost. `totalCount` is the filtered count; cost and token totals are page totals for the returned playbooks. Superadmins may filter across organizations; organization admins are scoped to their own `organization_id` even though the backend reads through the service role. Service-role reads are not RLS proof, so live evidence still needs a real admin session and disposable staging data before it can be used as a mutation-smoke acceptance artifact.
+
+Operator evidence should include a screenshot or exported trace from `/admin/generation/career-playbooks/costs` showing at least one completed Career Playbook with per-node rows and aggregate totals. If staging does not expose `public.career_playbooks`, record the schema blocker instead of running mutation smoke.
 
 The 10-concurrent-generation load test should run against isolated staging resources:
 

--- a/packages/course-gen-platform/src/server/routers/admin/career-playbook-costs.ts
+++ b/packages/course-gen-platform/src/server/routers/admin/career-playbook-costs.ts
@@ -1,0 +1,253 @@
+/**
+ * Career Playbook admin cost evidence.
+ * @module server/routers/admin/career-playbook-costs
+ */
+
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import {
+  CareerPlaybookCostBreakdownSchema,
+  CareerPlaybookPlaybookStatusSchema,
+  type CareerPlaybookCostBreakdown,
+} from '@megacampus/shared-types';
+import { router } from '../../trpc';
+import { adminProcedure } from '../../procedures';
+import { getSupabaseAdmin } from '../../../shared/supabase/admin';
+import { logger } from '../../../shared/logger/index.js';
+
+interface CareerPlaybookCostRow {
+  id: string;
+  user_id: string;
+  organization_id: string;
+  status: string;
+  language: string;
+  position_title: string | null;
+  cost_breakdown: unknown;
+  created_at: string;
+  completed_at: string | null;
+}
+
+interface CareerPlaybookCostQuery {
+  select: (columns: string, options?: { count?: 'exact' }) => CareerPlaybookCostQuery;
+  eq: (column: string, value: unknown) => CareerPlaybookCostQuery;
+  order: (column: string, options?: { ascending?: boolean }) => CareerPlaybookCostQuery;
+  range: (
+    from: number,
+    to: number
+  ) => Promise<{ data: CareerPlaybookCostRow[] | null; count: number | null; error: unknown }>;
+}
+
+interface CareerPlaybookCostSupabase {
+  from(table: 'career_playbooks'): CareerPlaybookCostQuery;
+}
+
+const CareerPlaybookCostNodeEvidenceSchema = z.object({
+  stage: z.string(),
+  node: z.string(),
+  model: z.string(),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+});
+
+const CareerPlaybookCostEvidenceItemSchema = z.object({
+  playbookId: z.string().uuid(),
+  title: z.string(),
+  status: CareerPlaybookPlaybookStatusSchema,
+  costBreakdownValid: z.boolean(),
+  language: z.string(),
+  organizationId: z.string().uuid(),
+  userId: z.string().uuid(),
+  createdAt: z.string(),
+  completedAt: z.string().nullable(),
+  totalCostUsd: z.number().nonnegative(),
+  totalInputTokens: z.number().int().nonnegative(),
+  totalOutputTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+  nodes: z.array(CareerPlaybookCostNodeEvidenceSchema),
+});
+
+const CareerPlaybookCostEvidenceResponseSchema = z.object({
+  totalCount: z.number().int().nonnegative(),
+  pageCount: z.number().int().nonnegative(),
+  totalCostUsd: z.number().nonnegative(),
+  totalInputTokens: z.number().int().nonnegative(),
+  totalOutputTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+  playbooks: z.array(CareerPlaybookCostEvidenceItemSchema),
+});
+
+const CareerPlaybookCostEvidenceInputSchema = z.object({
+  playbookId: z.string().uuid().optional(),
+  organizationId: z.string().uuid().optional(),
+  status: CareerPlaybookPlaybookStatusSchema.optional(),
+  limit: z.number().min(1).max(100).default(50),
+  offset: z.number().min(0).default(0),
+});
+
+function errorMessageFrom(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stageFromNode(node: string): string {
+  if (node === 'followupGenerator') return 'followup';
+  if (node === 'specBuilder') return 'spec';
+  if (node === 'crossBlockJudge') return 'judge';
+  if (node === 'blockRegenerator') return 'regeneration';
+
+  const groupMatch = /^group(\d+)Generator$/.exec(node);
+  if (groupMatch) return `group_${groupMatch[1]}`;
+
+  return node;
+}
+
+function parseCostBreakdown(raw: unknown): {
+  costBreakdown: CareerPlaybookCostBreakdown;
+  valid: boolean;
+} {
+  const parsed = CareerPlaybookCostBreakdownSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      costBreakdown: { nodeCosts: [], total_cost_usd: 0 },
+      valid: false,
+    };
+  }
+
+  return { costBreakdown: parsed.data, valid: true };
+}
+
+function roundMetric(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function mapCostRow(row: CareerPlaybookCostRow) {
+  const parsedStatus = CareerPlaybookPlaybookStatusSchema.safeParse(row.status);
+  const status = parsedStatus.success ? parsedStatus.data : 'failed';
+  const { costBreakdown, valid } = parseCostBreakdown(row.cost_breakdown);
+  const nodes = costBreakdown.nodeCosts.map(nodeCost => {
+    const inputTokens = nodeCost.input_tokens;
+    const outputTokens = nodeCost.output_tokens;
+    return {
+      stage: stageFromNode(nodeCost.node),
+      node: nodeCost.node,
+      model: nodeCost.model,
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+      costUsd: nodeCost.cost_usd,
+    };
+  });
+  const totalInputTokens = nodes.reduce((sum, node) => sum + node.inputTokens, 0);
+  const totalOutputTokens = nodes.reduce((sum, node) => sum + node.outputTokens, 0);
+  const nodeCostTotal = nodes.reduce((sum, node) => sum + node.costUsd, 0);
+  const totalCostUsd =
+    costBreakdown.total_cost_usd > 0 || nodeCostTotal === 0
+      ? costBreakdown.total_cost_usd
+      : nodeCostTotal;
+
+  return {
+    playbookId: row.id,
+    title: row.position_title ?? 'Untitled Career Playbook',
+    status,
+    costBreakdownValid: valid,
+    language: row.language,
+    organizationId: row.organization_id,
+    userId: row.user_id,
+    createdAt: row.created_at,
+    completedAt: row.completed_at,
+    totalCostUsd: roundMetric(totalCostUsd),
+    totalInputTokens,
+    totalOutputTokens,
+    totalTokens: totalInputTokens + totalOutputTokens,
+    nodes,
+  };
+}
+
+export const careerPlaybookCostsRouter = router({
+  getCareerPlaybookCostEvidence: adminProcedure
+    .input(CareerPlaybookCostEvidenceInputSchema)
+    .output(CareerPlaybookCostEvidenceResponseSchema)
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user) {
+        throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Authentication required' });
+      }
+
+      if (
+        ctx.user.role !== 'superadmin' &&
+        input.organizationId &&
+        input.organizationId !== ctx.user.organizationId
+      ) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Organization admins can only view their own organization cost evidence',
+        });
+      }
+
+      try {
+        const supabase = getSupabaseAdmin() as unknown as CareerPlaybookCostSupabase;
+        let query = supabase
+          .from('career_playbooks')
+          .select(
+            'id, user_id, organization_id, status, language, position_title, cost_breakdown, created_at, completed_at',
+            { count: 'exact' }
+          )
+          .order('created_at', { ascending: false });
+
+        if (input.playbookId) {
+          query = query.eq('id', input.playbookId);
+        }
+
+        if (ctx.user.role === 'superadmin') {
+          if (input.organizationId) {
+            query = query.eq('organization_id', input.organizationId);
+          }
+        } else {
+          query = query.eq('organization_id', ctx.user.organizationId);
+        }
+
+        if (input.status) {
+          query = query.eq('status', input.status);
+        }
+
+        const { data, count, error } = await query.range(
+          input.offset,
+          input.offset + input.limit - 1
+        );
+
+        if (error) {
+          throw new Error(errorMessageFrom(error));
+        }
+
+        const playbooks = (data ?? []).map(mapCostRow);
+        const totalInputTokens = playbooks.reduce(
+          (sum, playbook) => sum + playbook.totalInputTokens,
+          0
+        );
+        const totalOutputTokens = playbooks.reduce(
+          (sum, playbook) => sum + playbook.totalOutputTokens,
+          0
+        );
+        const totalCostUsd = playbooks.reduce((sum, playbook) => sum + playbook.totalCostUsd, 0);
+
+        return {
+          totalCount: count ?? playbooks.length,
+          pageCount: playbooks.length,
+          totalCostUsd: roundMetric(totalCostUsd),
+          totalInputTokens,
+          totalOutputTokens,
+          totalTokens: totalInputTokens + totalOutputTokens,
+          playbooks,
+        };
+      } catch (error) {
+        logger.error({ error, input }, 'Failed to fetch Career Playbook cost evidence');
+        if (error instanceof TRPCError) throw error;
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to fetch Career Playbook cost evidence: ${errorMessageFrom(error)}`,
+        });
+      }
+    }),
+});
+
+export type CareerPlaybookCostsRouter = typeof careerPlaybookCostsRouter;

--- a/packages/course-gen-platform/src/server/routers/admin/index.ts
+++ b/packages/course-gen-platform/src/server/routers/admin/index.ts
@@ -16,6 +16,7 @@
  * - auditLogs: listAuditLogs
  * - generationMonitoring: getGenerationTrace, getCourseGenerationDetails, triggerStage6ForLesson,
  *                         regenerateLessonWithRefinement, getGenerationHistory, exportTraceData, finalizeCourse
+ * - careerPlaybookCosts: getCareerPlaybookCostEvidence
  * - tiers: listTiers, getTier, updateTier, resetTierToDefaults
  * - logs: list, getById, updateStatus, bulkUpdateStatus (error logs and generation traces)
  *
@@ -31,6 +32,7 @@ import { coursesRouter } from './courses';
 import { apiKeysRouter } from './api-keys';
 import { auditLogsRouter } from './audit-logs';
 import { generationMonitoringRouter } from './generation-monitoring';
+import { careerPlaybookCostsRouter } from './career-playbook-costs';
 import { tiersRouter } from './tiers';
 import { logsRouter } from './logs';
 
@@ -64,6 +66,9 @@ export const adminRouter = router({
 
   // Generation Monitoring (7 procedures)
   ...generationMonitoringRouter._def.procedures,
+
+  // Career Playbook costs (1 procedure)
+  ...careerPlaybookCostsRouter._def.procedures,
 
   // Tiers (4 procedures: listTiers, getTier, updateTier, resetTierToDefaults)
   ...tiersRouter._def.procedures,

--- a/packages/course-gen-platform/tests/unit/server/routers/admin-career-playbook-costs.test.ts
+++ b/packages/course-gen-platform/tests/unit/server/routers/admin-career-playbook-costs.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+
+vi.mock('@/shared/supabase/admin', () => ({
+  getSupabaseAdmin: vi.fn(() => ({
+    from: mocks.from,
+  })),
+}));
+
+vi.mock('@/shared/logger/index.js', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { adminRouter } from '@/server/routers/admin';
+import type { Context } from '@/server/trpc';
+
+const orgA = '22222222-2222-4222-8222-222222222222';
+const orgB = '99999999-9999-4999-8999-999999999999';
+
+const superadminContext: Context = {
+  user: {
+    id: '11111111-1111-4111-8111-111111111111',
+    email: 'root@example.com',
+    role: 'superadmin',
+    organizationId: orgA,
+  },
+  req: new Request('http://localhost/trpc'),
+};
+
+const adminContext: Context = {
+  user: {
+    id: '33333333-3333-4333-8333-333333333333',
+    email: 'admin@example.com',
+    role: 'admin',
+    organizationId: orgA,
+  },
+  req: new Request('http://localhost/trpc'),
+};
+
+function playbookRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '44444444-4444-4444-8444-444444444444',
+    user_id: '55555555-5555-4555-8555-555555555555',
+    organization_id: orgA,
+    status: 'completed',
+    language: 'ru',
+    position_title: 'Sales Manager B2B',
+    cost_breakdown: {
+      nodeCosts: [
+        {
+          node: 'specBuilder',
+          model: 'anthropic/claude-sonnet-4.5',
+          input_tokens: 1200,
+          output_tokens: 400,
+          cost_usd: 0.012,
+        },
+        {
+          node: 'group2Generator',
+          model: 'anthropic/claude-sonnet-4.5',
+          input_tokens: 2200,
+          output_tokens: 900,
+          cost_usd: 0.031,
+        },
+      ],
+      total_cost_usd: 0.043,
+    },
+    created_at: '2026-05-19T10:00:00.000Z',
+    completed_at: '2026-05-19T10:10:00.000Z',
+    ...overrides,
+  };
+}
+
+function createCareerPlaybookCostsBuilder(data: unknown[], count = data.length) {
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    order: vi.fn(() => builder),
+    range: vi.fn(() => Promise.resolve({ data, count, error: null })),
+  };
+
+  return builder;
+}
+
+describe('admin Career Playbook cost evidence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('aggregates Career Playbook cost breakdown by playbook and node', async () => {
+    const builder = createCareerPlaybookCostsBuilder([playbookRow()]);
+    mocks.from.mockReturnValue(builder);
+
+    const caller = adminRouter.createCaller(superadminContext);
+    const result = await caller.getCareerPlaybookCostEvidence({ limit: 10 });
+
+    expect(mocks.from).toHaveBeenCalledWith('career_playbooks');
+    expect(builder.select).toHaveBeenCalledWith(
+      'id, user_id, organization_id, status, language, position_title, cost_breakdown, created_at, completed_at',
+      { count: 'exact' }
+    );
+    expect(result).toMatchObject({
+      totalCount: 1,
+      pageCount: 1,
+      totalCostUsd: 0.043,
+      totalInputTokens: 3400,
+      totalOutputTokens: 1300,
+      playbooks: [
+        {
+          playbookId: '44444444-4444-4444-8444-444444444444',
+          title: 'Sales Manager B2B',
+          costBreakdownValid: true,
+          totalCostUsd: 0.043,
+          totalInputTokens: 3400,
+          totalOutputTokens: 1300,
+          totalTokens: 4700,
+          nodes: [
+            {
+              stage: 'spec',
+              node: 'specBuilder',
+              model: 'anthropic/claude-sonnet-4.5',
+              inputTokens: 1200,
+              outputTokens: 400,
+              totalTokens: 1600,
+              costUsd: 0.012,
+            },
+            {
+              stage: 'group_2',
+              node: 'group2Generator',
+              inputTokens: 2200,
+              outputTokens: 900,
+              totalTokens: 3100,
+              costUsd: 0.031,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('scopes organization admins to their own organization even without an input filter', async () => {
+    const builder = createCareerPlaybookCostsBuilder([playbookRow()]);
+    mocks.from.mockReturnValue(builder);
+
+    const caller = adminRouter.createCaller(adminContext);
+    await caller.getCareerPlaybookCostEvidence({});
+
+    expect(builder.eq).toHaveBeenCalledWith('organization_id', orgA);
+  });
+
+  it('keeps page totals distinct from the full filtered count', async () => {
+    const builder = createCareerPlaybookCostsBuilder([playbookRow()], 2);
+    mocks.from.mockReturnValue(builder);
+
+    const caller = adminRouter.createCaller(superadminContext);
+    const result = await caller.getCareerPlaybookCostEvidence({ limit: 1 });
+
+    expect(result.totalCount).toBe(2);
+    expect(result.pageCount).toBe(1);
+    expect(result.totalCostUsd).toBe(0.043);
+    expect(result.totalTokens).toBe(4700);
+  });
+
+  it('marks invalid cost breakdowns instead of presenting them as verified evidence', async () => {
+    const builder = createCareerPlaybookCostsBuilder([
+      playbookRow({
+        cost_breakdown: {
+          nodeCosts: [{ node: '', model: '', input_tokens: -1, output_tokens: 0, cost_usd: 0 }],
+          total_cost_usd: 0,
+        },
+      }),
+    ]);
+    mocks.from.mockReturnValue(builder);
+
+    const caller = adminRouter.createCaller(superadminContext);
+    const result = await caller.getCareerPlaybookCostEvidence({});
+
+    expect(result.playbooks[0]).toMatchObject({
+      costBreakdownValid: false,
+      totalCostUsd: 0,
+      totalTokens: 0,
+      nodes: [],
+    });
+  });
+
+  it('rejects organization admins who request another organization filter', async () => {
+    const builder = createCareerPlaybookCostsBuilder([]);
+    mocks.from.mockReturnValue(builder);
+
+    const caller = adminRouter.createCaller(adminContext);
+
+    await expect(
+      caller.getCareerPlaybookCostEvidence({ organizationId: orgB })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(builder.range).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/[locale]/admin/generation/career-playbooks/costs/page.tsx
+++ b/packages/web/app/[locale]/admin/generation/career-playbooks/costs/page.tsx
@@ -1,0 +1,54 @@
+import { getTranslations, setRequestLocale } from 'next-intl/server'
+
+import {
+  CareerPlaybookCostEvidenceTable,
+  type CareerPlaybookCostEvidence,
+} from '@/components/career-playbook/admin/CareerPlaybookCostEvidenceTable'
+import { getServerTrpcClient } from '@/lib/trpc/server-caller'
+import { Locale } from '@/src/i18n/config'
+
+type Props = {
+  params: Promise<{ locale: Locale }>
+}
+
+export default async function CareerPlaybookCostsPage({ params }: Props) {
+  const { locale } = await params
+  setRequestLocale(locale)
+
+  const t = await getTranslations('admin.careerPlaybookCosts')
+  const client = await getServerTrpcClient()
+  const evidence = (await client.admin.getCareerPlaybookCostEvidence.query({
+    limit: 50,
+  })) as CareerPlaybookCostEvidence
+
+  return (
+    <div className="flex min-h-[calc(100vh-100px)] flex-col space-y-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">{t('title')}</h1>
+        <p className="max-w-3xl text-gray-600 dark:text-gray-300">{t('description')}</p>
+      </div>
+
+      <CareerPlaybookCostEvidenceTable
+        evidence={evidence}
+        locale={locale}
+        emptyLabel={t('empty')}
+        labels={{
+          playbooks: t('labels.playbooks'),
+          playbookSingular: t('labels.playbookSingular'),
+          playbookPlural: t('labels.playbookPlural'),
+          totalCost: t('labels.totalCost'),
+          tokens: t('labels.tokens'),
+          inputOutput: t('labels.inputOutput'),
+          stage: t('labels.stage'),
+          node: t('labels.node'),
+          model: t('labels.model'),
+          input: t('labels.input'),
+          output: t('labels.output'),
+          cost: t('labels.cost'),
+          created: t('labels.created'),
+          invalidCostBreakdown: t('labels.invalidCostBreakdown'),
+        }}
+      />
+    </div>
+  )
+}

--- a/packages/web/app/[locale]/admin/generation/history/page.tsx
+++ b/packages/web/app/[locale]/admin/generation/history/page.tsx
@@ -1,4 +1,8 @@
 import { getTranslations, setRequestLocale } from 'next-intl/server'
+import { Coins } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Link } from '@/src/i18n/navigation'
 import { Locale } from '@/src/i18n/config'
 import { HistoryTable } from '@/components/generation-monitoring/history-table'
 
@@ -14,11 +18,17 @@ export default async function HistoryPage({ params }: Props) {
 
   return (
     <div className="flex h-[calc(100vh-100px)] flex-col space-y-6 p-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
-          {t('title')}
-        </h1>
-        <p className="text-gray-600 dark:text-gray-300">{t('description')}</p>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">{t('title')}</h1>
+          <p className="text-gray-600 dark:text-gray-300">{t('description')}</p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/admin/generation/career-playbooks/costs">
+            <Coins className="h-4 w-4" />
+            {t('actions.careerPlaybookCosts')}
+          </Link>
+        </Button>
       </div>
 
       <div className="min-h-0 flex-1">

--- a/packages/web/components/career-playbook/admin/CareerPlaybookCostEvidenceTable.tsx
+++ b/packages/web/components/career-playbook/admin/CareerPlaybookCostEvidenceTable.tsx
@@ -1,0 +1,253 @@
+import { Fragment } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+export interface CareerPlaybookCostNodeEvidence {
+  stage: string
+  node: string
+  model: string
+  inputTokens: number
+  outputTokens: number
+  totalTokens: number
+  costUsd: number
+}
+
+export interface CareerPlaybookCostPlaybookEvidence {
+  playbookId: string
+  title: string | null
+  status: string
+  costBreakdownValid: boolean
+  language: string
+  organizationId: string
+  userId: string
+  createdAt: string | null
+  completedAt: string | null
+  totalCostUsd: number
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalTokens: number
+  nodes: CareerPlaybookCostNodeEvidence[]
+}
+
+export interface CareerPlaybookCostEvidence {
+  totalCount: number
+  pageCount: number
+  totalCostUsd: number
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalTokens: number
+  playbooks: CareerPlaybookCostPlaybookEvidence[]
+}
+
+interface CareerPlaybookCostEvidenceTableProps {
+  evidence: CareerPlaybookCostEvidence
+  locale: string
+  emptyLabel?: string
+  labels?: Partial<CareerPlaybookCostEvidenceLabels>
+}
+
+interface CareerPlaybookCostEvidenceLabels {
+  playbooks: string
+  playbookSingular: string
+  playbookPlural: string
+  totalCost: string
+  tokens: string
+  inputOutput: string
+  stage: string
+  node: string
+  model: string
+  input: string
+  output: string
+  cost: string
+  created: string
+  invalidCostBreakdown: string
+}
+
+const DASH = '-'
+const DEFAULT_LABELS: CareerPlaybookCostEvidenceLabels = {
+  playbooks: 'Playbooks',
+  playbookSingular: 'playbook',
+  playbookPlural: 'playbooks',
+  totalCost: 'Total cost',
+  tokens: 'Tokens',
+  inputOutput: 'Input / output',
+  stage: 'Stage',
+  node: 'Node',
+  model: 'Model',
+  input: 'Input',
+  output: 'Output',
+  cost: 'Cost',
+  created: 'Created',
+  invalidCostBreakdown: 'Invalid cost data',
+}
+
+function formatNumber(value: number, locale: string): string {
+  return new Intl.NumberFormat(locale).format(value)
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toFixed(4)}`
+}
+
+function formatDate(value: string | null, locale: string): string {
+  if (!value) return DASH
+
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value))
+}
+
+function playbookLabel(
+  pageCount: number,
+  totalCount: number,
+  labels: CareerPlaybookCostEvidenceLabels
+): string {
+  const noun = totalCount === 1 ? labels.playbookSingular : labels.playbookPlural
+  if (pageCount === totalCount) {
+    return `${totalCount} ${noun}`
+  }
+
+  return `${pageCount} of ${totalCount} ${noun}`
+}
+
+export function CareerPlaybookCostEvidenceTable({
+  evidence,
+  locale,
+  emptyLabel = 'No Career Playbook costs found',
+  labels: labelOverrides,
+}: CareerPlaybookCostEvidenceTableProps) {
+  const labels = { ...DEFAULT_LABELS, ...labelOverrides }
+
+  if (evidence.playbooks.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-gray-300 bg-white p-8 text-center text-sm text-gray-600 dark:border-slate-700 dark:bg-slate-950 dark:text-gray-300">
+        {emptyLabel}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-md border bg-white p-4 dark:border-slate-800 dark:bg-slate-950">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400">
+            {labels.playbooks}
+          </div>
+          <div className="mt-1 text-2xl font-semibold text-gray-950 dark:text-gray-50">
+            {playbookLabel(evidence.pageCount, evidence.totalCount, labels)}
+          </div>
+        </div>
+        <div className="rounded-md border bg-white p-4 dark:border-slate-800 dark:bg-slate-950">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400">
+            {labels.totalCost}
+          </div>
+          <div className="mt-1 text-2xl font-semibold text-gray-950 dark:text-gray-50">
+            {formatUsd(evidence.totalCostUsd)}
+          </div>
+        </div>
+        <div className="rounded-md border bg-white p-4 dark:border-slate-800 dark:bg-slate-950">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400">
+            {labels.tokens}
+          </div>
+          <div className="mt-1 text-2xl font-semibold text-gray-950 dark:text-gray-50">
+            {formatNumber(evidence.totalTokens, locale)}
+          </div>
+        </div>
+        <div className="rounded-md border bg-white p-4 dark:border-slate-800 dark:bg-slate-950">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400">
+            {labels.inputOutput}
+          </div>
+          <div className="mt-1 text-2xl font-semibold text-gray-950 dark:text-gray-50">
+            {formatNumber(evidence.totalInputTokens, locale)} /{' '}
+            {formatNumber(evidence.totalOutputTokens, locale)}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-md border bg-white dark:border-slate-800 dark:bg-slate-950">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{labels.stage}</TableHead>
+              <TableHead>{labels.node}</TableHead>
+              <TableHead>{labels.model}</TableHead>
+              <TableHead className="text-right">{labels.input}</TableHead>
+              <TableHead className="text-right">{labels.output}</TableHead>
+              <TableHead className="text-right">{labels.tokens}</TableHead>
+              <TableHead className="text-right">{labels.cost}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {evidence.playbooks.map((playbook) => (
+              <Fragment key={playbook.playbookId}>
+                <TableRow className="bg-gray-50 hover:bg-gray-50 dark:bg-slate-900/60 dark:hover:bg-slate-900/60">
+                  <TableCell colSpan={3}>
+                    <div className="max-w-[32rem] space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="truncate font-medium text-gray-950 dark:text-gray-50">
+                          {playbook.title || playbook.playbookId}
+                        </span>
+                        <Badge variant="outline" className="capitalize">
+                          {playbook.status}
+                        </Badge>
+                        {!playbook.costBreakdownValid && (
+                          <Badge variant="destructive">{labels.invalidCostBreakdown}</Badge>
+                        )}
+                      </div>
+                      <div className="font-mono text-xs text-gray-500 dark:text-gray-400">
+                        {playbook.playbookId}
+                      </div>
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                        {labels.created} {formatDate(playbook.createdAt, locale)}
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right font-mono">
+                    {formatNumber(playbook.totalInputTokens, locale)}
+                  </TableCell>
+                  <TableCell className="text-right font-mono">
+                    {formatNumber(playbook.totalOutputTokens, locale)}
+                  </TableCell>
+                  <TableCell className="text-right font-mono">
+                    {formatNumber(playbook.totalTokens, locale)}
+                  </TableCell>
+                  <TableCell className="text-right font-mono">
+                    {formatUsd(playbook.totalCostUsd)}
+                  </TableCell>
+                </TableRow>
+                {playbook.nodes.map((node) => (
+                  <TableRow key={`${playbook.playbookId}-${node.stage}-${node.node}`}>
+                    <TableCell>{node.stage}</TableCell>
+                    <TableCell className="font-mono text-xs">{node.node}</TableCell>
+                    <TableCell className="max-w-[18rem] truncate">{node.model}</TableCell>
+                    <TableCell className="text-right font-mono">
+                      {formatNumber(node.inputTokens, locale)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">
+                      {formatNumber(node.outputTokens, locale)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">
+                      {formatNumber(node.totalTokens, locale)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">
+                      {formatUsd(node.costUsd)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </Fragment>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}

--- a/packages/web/messages/en/admin.json
+++ b/packages/web/messages/en/admin.json
@@ -137,7 +137,8 @@
     },
     "actions": {
       "openWorkflow": "Open Workflow",
-      "adminPanel": "Admin Panel"
+      "adminPanel": "Admin Panel",
+      "careerPlaybookCosts": "Career Playbook costs"
     },
     "empty": {
       "title": "No generations found",
@@ -147,6 +148,27 @@
       "showing": "Showing {from} to {to} of {total} results",
       "previous": "Previous",
       "next": "Next"
+    }
+  },
+  "careerPlaybookCosts": {
+    "title": "Career Playbook Cost Evidence",
+    "description": "Review Career Playbook generation costs by playbook, stage, node, model, tokens, and USD totals.",
+    "empty": "No Career Playbook costs found",
+    "labels": {
+      "playbooks": "Playbooks",
+      "playbookSingular": "playbook",
+      "playbookPlural": "playbooks",
+      "totalCost": "Total cost",
+      "tokens": "Tokens",
+      "inputOutput": "Input / output",
+      "stage": "Stage",
+      "node": "Node",
+      "model": "Model",
+      "input": "Input",
+      "output": "Output",
+      "cost": "Cost",
+      "created": "Created",
+      "invalidCostBreakdown": "Invalid cost data"
     }
   },
   "pipeline": {

--- a/packages/web/messages/ru/admin.json
+++ b/packages/web/messages/ru/admin.json
@@ -137,7 +137,8 @@
     },
     "actions": {
       "openWorkflow": "Открыть Workflow",
-      "adminPanel": "Панель администратора"
+      "adminPanel": "Панель администратора",
+      "careerPlaybookCosts": "Затраты Career Playbook"
     },
     "empty": {
       "title": "Генерации не найдены",
@@ -147,6 +148,27 @@
       "showing": "Показано {from} - {to} из {total} результатов",
       "previous": "Назад",
       "next": "Вперёд"
+    }
+  },
+  "careerPlaybookCosts": {
+    "title": "Подтверждение затрат Career Playbook",
+    "description": "Просмотр затрат генерации Career Playbook по плейбуку, этапу, узлу, модели, токенам и сумме в USD.",
+    "empty": "Затраты Career Playbook не найдены",
+    "labels": {
+      "playbooks": "Плейбуки",
+      "playbookSingular": "плейбук",
+      "playbookPlural": "плейбуков",
+      "totalCost": "Общие затраты",
+      "tokens": "Токены",
+      "inputOutput": "Вход / выход",
+      "stage": "Этап",
+      "node": "Узел",
+      "model": "Модель",
+      "input": "Вход",
+      "output": "Выход",
+      "cost": "Затраты",
+      "created": "Создан",
+      "invalidCostBreakdown": "Некорректные данные затрат"
     }
   },
   "pipeline": {

--- a/packages/web/tests/unit/components/career-playbook/admin-cost-evidence.test.tsx
+++ b/packages/web/tests/unit/components/career-playbook/admin-cost-evidence.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  CareerPlaybookCostEvidenceTable,
+  type CareerPlaybookCostEvidence,
+} from '@/components/career-playbook/admin/CareerPlaybookCostEvidenceTable'
+
+const evidence: CareerPlaybookCostEvidence = {
+  totalCount: 1,
+  pageCount: 1,
+  totalCostUsd: 0.043,
+  totalInputTokens: 3400,
+  totalOutputTokens: 1300,
+  totalTokens: 4700,
+  playbooks: [
+    {
+      playbookId: '44444444-4444-4444-8444-444444444444',
+      title: 'Sales Manager B2B',
+      status: 'completed',
+      costBreakdownValid: true,
+      language: 'ru',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      userId: '55555555-5555-4555-8555-555555555555',
+      createdAt: '2026-05-19T10:00:00.000Z',
+      completedAt: '2026-05-19T10:10:00.000Z',
+      totalCostUsd: 0.043,
+      totalInputTokens: 3400,
+      totalOutputTokens: 1300,
+      totalTokens: 4700,
+      nodes: [
+        {
+          stage: 'spec',
+          node: 'specBuilder',
+          model: 'anthropic/claude-sonnet-4.5',
+          inputTokens: 1200,
+          outputTokens: 400,
+          totalTokens: 1600,
+          costUsd: 0.012,
+        },
+        {
+          stage: 'group_2',
+          node: 'group2Generator',
+          model: 'anthropic/claude-sonnet-4.5',
+          inputTokens: 2200,
+          outputTokens: 900,
+          totalTokens: 3100,
+          costUsd: 0.031,
+        },
+      ],
+    },
+  ],
+}
+
+describe('CareerPlaybookCostEvidenceTable', () => {
+  it('renders aggregate totals and per-node cost evidence', () => {
+    render(<CareerPlaybookCostEvidenceTable evidence={evidence} locale="en" />)
+
+    expect(screen.getByText('1 playbook')).toBeInTheDocument()
+    expect(screen.getAllByText('$0.0430')[0]).toBeInTheDocument()
+    expect(screen.getAllByText('4,700')[0]).toBeInTheDocument()
+
+    const nodeRows = screen.getAllByRole('row').filter((row) => within(row).queryByText('spec'))
+    expect(nodeRows).toHaveLength(1)
+    expect(within(nodeRows[0]).getByText('specBuilder')).toBeInTheDocument()
+    expect(within(nodeRows[0]).getByText('1,200')).toBeInTheDocument()
+    expect(within(nodeRows[0]).getByText('$0.0120')).toBeInTheDocument()
+
+    expect(screen.getByText('group_2')).toBeInTheDocument()
+    expect(screen.getByText('group2Generator')).toBeInTheDocument()
+  })
+
+  it('renders an empty evidence state', () => {
+    render(
+      <CareerPlaybookCostEvidenceTable
+        locale="en"
+        evidence={{
+          totalCount: 0,
+          pageCount: 0,
+          totalCostUsd: 0,
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
+          totalTokens: 0,
+          playbooks: [],
+        }}
+      />
+    )
+
+    expect(screen.getByText('No Career Playbook costs found')).toBeInTheDocument()
+  })
+
+  it('distinguishes shown page totals from the full filtered count', () => {
+    render(
+      <CareerPlaybookCostEvidenceTable
+        locale="en"
+        evidence={{
+          ...evidence,
+          totalCount: 2,
+          pageCount: 1,
+        }}
+      />
+    )
+
+    expect(screen.getByText('1 of 2 playbooks')).toBeInTheDocument()
+    expect(screen.getAllByText('$0.0430')[0]).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- adds `admin.getCareerPlaybookCostEvidence` for Career Playbook cost evidence from `career_playbooks.cost_breakdown`
- adds `/admin/generation/career-playbooks/costs` and a link from admin generation history
- records Phase 11 cost-evidence docs, stage artifact, Beads state, org-admin scoping, page totals, and invalid cost payload marking

## Verification
- `SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key NODE_ENV=test pnpm --filter @megacampus/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/server/routers/admin-career-playbook-costs.test.ts`
- `pnpm --filter @megacampus/web exec vitest run tests/unit/components/career-playbook/admin-cost-evidence.test.tsx`
- `pnpm type-check`
- `pnpm lint`
- `SUPABASE_SERVICE_ROLE_KEY=test-service-role NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon pnpm build`
- `scripts/orchestration/run_process_verification.sh`
- `python3 scripts/orchestration/validate_artifact.py .codex/stages/mc2-db696.11/artifacts/mc2-db696.11.4-cost-evidence.md`

## Notes
- No live staging mutations, migrations, queue operations, cleanup, workers, or LLM/API calls were run.
- `mc2-db696.11.5` remains blocked on staging schema, TOKEN/auth, disposable fixtures, dedicated non-default `BULLMQ_QUEUE_NAME`, cleanup authorization, and accepted LLM/API budget.
