### PR TITLE
feat(career-playbook): add gated live smoke runner

### DIFF
--- a/.codex/handoff.md
+++ b/.codex/handoff.md
@@ -2,7 +2,7 @@
 
 Updated: 2026-05-21
 Current working branch: `codex/career-playbook-live-smoke`
-Base branch: `origin/develop`; Current PR: none
+Base branch: `origin/develop`; Current PR: [#41](https://github.com/maslennikov-ig/MC-2/pull/41)
 
 ## Current state
 
@@ -14,7 +14,7 @@ Base branch: `origin/develop`; Current PR: none
 - `mc2-db696.11.4` is delivered and merged through PR #39: admin cost evidence endpoint `admin.getCareerPlaybookCostEvidence`, page `/admin/generation/career-playbooks/costs`, generation-history link, org-admin scoping, page-total semantics, invalid cost payload marking, tests, and docs.
 - `mc2-db696.11.5` staging schema/read-only readiness advanced through PR #40 on 2026-05-21: the Career Playbook Supabase migration is applied, RLS/seed/policies are verified, migration history includes both MCP generated and file-version rows, and read-only staging preflight passes with `BULLMQ_QUEUE_NAME=career-playbook-smoke-20260521-pr-ready`.
 - Career Playbook minimal model routing is configured in Supabase and encoded in migration `20260521101000_allow_career_playbook_model_phases`: `minimax/minimax-m2.7` for `stage_career_playbook_spec` and `stage_career_playbook_judge`; `deepseek/deepseek-v4-flash` for follow-up, groups 1-6, and regenerator.
-- `mc2-db696.11.5` live-smoke runner work is prepared on `codex/career-playbook-live-smoke`: `smoke:career-playbook:live` has non-mutating `plan` mode, gated `mutation-smoke` mode, deterministic evidence validation, and a dry-run cleanup manifest.
+- PR #41 is open and mergeable for `mc2-db696.11.5` live-smoke runner work on `codex/career-playbook-live-smoke`: `smoke:career-playbook:live` has non-mutating `plan` mode, gated `mutation-smoke` mode, deterministic evidence validation, and a dry-run cleanup manifest.
 - Live mutation smoke has not run. Do not trigger LLM-backed generation until disposable fixtures, token/storage state, cleanup scope, queue alignment between enqueuer and worker, and numeric API cost budget are explicit.
 - Primary worktree `/home/me/code/mc2` remains dirty on stale `feature/career-playbook-library-share`; its local `mc2-db696.13` worker/status transport patch was compared against `origin/develop` and left untouched because `origin/develop` already contains the landed implementation.
 - No billing or payment scope is part of the Career Playbook MVP work.
@@ -28,14 +28,14 @@ Base branch: `origin/develop`; Current PR: none
 ## Next recommended
 
 Next stage id: `mc2-db696.11`
-Recommended action: finish review/PR delivery for `codex/career-playbook-live-smoke`, then continue `mc2-db696.11.5` only when live mutation gates are explicit. Schema, read-only preflight, model routing, and the gated runner are ready; paid generation remains gated on auth/TOKEN or storage-state, disposable fixtures, queue alignment, exact cleanup scope, and accepted numeric LLM/API cost budget.
+Recommended action: let PR #41 CI/review complete, merge it into `develop` when authorized and green, then continue `mc2-db696.11.5` only when live mutation gates are explicit. Schema, read-only preflight, model routing, and the gated runner are ready; paid generation remains gated on auth/TOKEN or storage-state, disposable fixtures, queue alignment, exact cleanup scope, and accepted numeric LLM/API cost budget.
 
 If those gates are not satisfied, collect/prepare the missing staging readiness evidence before running any live mutation. Keep `mc2-db696.16` as the tracked P2 defer for future upload quota/dedupe reuse in the JD bridge.
 
 ## Starter prompt for next orchestrator
 
 ```text
-Use $orchestrator-stage to continue Career Playbook delivery. Read AGENTS.md, .codex/orchestrator.toml, .codex/handoff.md, .codex/project-index.md, .codex/stages/mc2-db696.11/summary.md, docs/plans/quiet-waddling-starfish.md, and docs/plans/career-playbook/* first. Use Beads as source of truth. PR #24-#40 have landed in develop. Important: the primary worktree is dirty on stale feature/career-playbook-library-share; do not discard it. mc2-db696.11.5 schema/read-only/model readiness is advanced and branch codex/career-playbook-live-smoke adds a gated live-smoke runner: default plan mode is non-mutating, mutation-smoke requires token, expected disposable user/org, tRPC URL, dedicated queue, cleanup scope, budget, and explicit confirmation, then emits deterministic evidence and a dry-run cleanup manifest. Continue live mutation smoke only after auth/TOKEN, disposable fixtures, enqueuer/worker queue alignment, cleanup scope, and numeric cost budget gates are explicit. Keep billing/payment out of MVP scope.
+Use $orchestrator-stage to continue Career Playbook delivery. Read AGENTS.md, .codex/orchestrator.toml, .codex/handoff.md, .codex/project-index.md, .codex/stages/mc2-db696.11/summary.md, docs/plans/quiet-waddling-starfish.md, and docs/plans/career-playbook/* first. Use Beads as source of truth. PR #24-#40 have landed in develop; PR #41 is open from codex/career-playbook-live-smoke to develop for the gated live-smoke runner. Important: the primary worktree is dirty on stale feature/career-playbook-library-share; do not discard it. Continue live mutation smoke only after auth/TOKEN, disposable fixtures, enqueuer/worker queue alignment, cleanup scope, and numeric cost budget gates are explicit. Keep billing/payment out of MVP scope.
 ```
 
 ## Explicit defers

--- a/.codex/handoff.md
+++ b/.codex/handoff.md
@@ -15,7 +15,7 @@ Current PR: none
 - `mc2-db696.11.4` is delivered and merged through PR #39: admin cost evidence endpoint `admin.getCareerPlaybookCostEvidence`, page `/admin/generation/career-playbooks/costs`, generation-history link, org-admin scoping, page-total semantics, invalid cost payload marking, tests, and docs.
 - `mc2-db696.11.5` staging schema/read-only readiness advanced through PR #40 on 2026-05-21: the Career Playbook Supabase migration is applied, RLS/seed/policies are verified, migration history includes both MCP generated and file-version rows, and read-only staging preflight passes with `BULLMQ_QUEUE_NAME=career-playbook-smoke-20260521-pr-ready`.
 - Career Playbook minimal model routing is configured in Supabase and encoded in migration `20260521101000_allow_career_playbook_model_phases`: `minimax/minimax-m2.7` for `stage_career_playbook_spec` and `stage_career_playbook_judge`; `deepseek/deepseek-v4-flash` for follow-up, groups 1-6, and regenerator.
-- Live mutation smoke has not run. Do not trigger LLM-backed generation until disposable fixtures, token/storage state, exact cleanup scope, queue alignment, and a numeric API cost budget are explicit.
+- Live mutation smoke has not run. Closeout triage on 2026-05-21 passed read-only staging preflight with `BULLMQ_QUEUE_NAME=career-playbook-smoke-20260521-live-closeout`, but local search found no `TOKEN`/storage-state and no live mutation script; do not trigger LLM-backed generation until disposable fixtures, cleanup scope, queue alignment, and numeric API cost budget are explicit.
 - Primary worktree `/home/me/code/mc2` remains dirty on stale `feature/career-playbook-library-share`; its local `mc2-db696.13` worker/status transport patch was compared against `origin/develop` and left untouched because `origin/develop` already contains the landed implementation.
 - No billing or payment scope is part of the Career Playbook MVP work.
 
@@ -28,7 +28,7 @@ Current PR: none
 ## Next recommended
 
 Next stage id: `mc2-db696.11`
-Recommended action: continue live-staging work under Phase 11. The first ready P1 is `mc2-db696.11.5`; schema, read-only preflight, and model routing are done, but live mutation smoke remains gated on auth/TOKEN, disposable fixtures, queue alignment between enqueuer and worker, exact cleanup scope, and accepted numeric LLM/API cost budget.
+Recommended action: continue live-staging work under Phase 11. The first ready P1 is `mc2-db696.11.5`; schema, read-only preflight, and model routing are done, but live mutation smoke remains gated on auth/TOKEN or storage-state, disposable fixtures, queue alignment between enqueuer and worker, exact cleanup scope, and accepted numeric LLM/API cost budget.
 
 If those gates are not satisfied, collect/prepare the missing staging readiness evidence before running any live mutation. Keep `mc2-db696.16` as the tracked P2 defer for future upload quota/dedupe reuse in the JD bridge.
 

--- a/.codex/handoff.md
+++ b/.codex/handoff.md
@@ -1,9 +1,8 @@
 # Orchestrator Handoff
 
 Updated: 2026-05-21
-Current working branch: `develop`
-Base branch: `develop`
-Current PR: none
+Current working branch: `codex/career-playbook-live-smoke`
+Base branch: `origin/develop`; Current PR: none
 
 ## Current state
 
@@ -15,7 +14,8 @@ Current PR: none
 - `mc2-db696.11.4` is delivered and merged through PR #39: admin cost evidence endpoint `admin.getCareerPlaybookCostEvidence`, page `/admin/generation/career-playbooks/costs`, generation-history link, org-admin scoping, page-total semantics, invalid cost payload marking, tests, and docs.
 - `mc2-db696.11.5` staging schema/read-only readiness advanced through PR #40 on 2026-05-21: the Career Playbook Supabase migration is applied, RLS/seed/policies are verified, migration history includes both MCP generated and file-version rows, and read-only staging preflight passes with `BULLMQ_QUEUE_NAME=career-playbook-smoke-20260521-pr-ready`.
 - Career Playbook minimal model routing is configured in Supabase and encoded in migration `20260521101000_allow_career_playbook_model_phases`: `minimax/minimax-m2.7` for `stage_career_playbook_spec` and `stage_career_playbook_judge`; `deepseek/deepseek-v4-flash` for follow-up, groups 1-6, and regenerator.
-- Live mutation smoke has not run. Closeout triage on 2026-05-21 passed read-only staging preflight with `BULLMQ_QUEUE_NAME=career-playbook-smoke-20260521-live-closeout`, but local search found no `TOKEN`/storage-state and no live mutation script; do not trigger LLM-backed generation until disposable fixtures, cleanup scope, queue alignment, and numeric API cost budget are explicit.
+- `mc2-db696.11.5` live-smoke runner work is prepared on `codex/career-playbook-live-smoke`: `smoke:career-playbook:live` has non-mutating `plan` mode, gated `mutation-smoke` mode, deterministic evidence validation, and a dry-run cleanup manifest.
+- Live mutation smoke has not run. Do not trigger LLM-backed generation until disposable fixtures, token/storage state, cleanup scope, queue alignment between enqueuer and worker, and numeric API cost budget are explicit.
 - Primary worktree `/home/me/code/mc2` remains dirty on stale `feature/career-playbook-library-share`; its local `mc2-db696.13` worker/status transport patch was compared against `origin/develop` and left untouched because `origin/develop` already contains the landed implementation.
 - No billing or payment scope is part of the Career Playbook MVP work.
 
@@ -28,18 +28,18 @@ Current PR: none
 ## Next recommended
 
 Next stage id: `mc2-db696.11`
-Recommended action: continue live-staging work under Phase 11. The first ready P1 is `mc2-db696.11.5`; schema, read-only preflight, and model routing are done, but live mutation smoke remains gated on auth/TOKEN or storage-state, disposable fixtures, queue alignment between enqueuer and worker, exact cleanup scope, and accepted numeric LLM/API cost budget.
+Recommended action: finish review/PR delivery for `codex/career-playbook-live-smoke`, then continue `mc2-db696.11.5` only when live mutation gates are explicit. Schema, read-only preflight, model routing, and the gated runner are ready; paid generation remains gated on auth/TOKEN or storage-state, disposable fixtures, queue alignment, exact cleanup scope, and accepted numeric LLM/API cost budget.
 
 If those gates are not satisfied, collect/prepare the missing staging readiness evidence before running any live mutation. Keep `mc2-db696.16` as the tracked P2 defer for future upload quota/dedupe reuse in the JD bridge.
 
 ## Starter prompt for next orchestrator
 
 ```text
-Use $orchestrator-stage to continue Career Playbook delivery. Read AGENTS.md, .codex/orchestrator.toml, .codex/handoff.md, .codex/project-index.md, .codex/stages/mc2-db696.11/summary.md, docs/plans/quiet-waddling-starfish.md, and docs/plans/career-playbook/* first. Use Beads as source of truth. PR #24-#40 have landed in develop. Important: the primary worktree is dirty on stale feature/career-playbook-library-share; do not discard it. mc2-db696.11.5 schema/read-only/model readiness is advanced: Career Playbook tables/RLS/seeds/policies are present, preflight passes with a dedicated queue name, and model routing is encoded in migration 20260521101000: MiniMax for spec/judge plus DeepSeek for the rest. Continue live mutation smoke only after auth/TOKEN, disposable fixtures, enqueuer/worker queue alignment, cleanup scope, and numeric cost budget gates are explicit. Keep billing/payment out of MVP scope.
+Use $orchestrator-stage to continue Career Playbook delivery. Read AGENTS.md, .codex/orchestrator.toml, .codex/handoff.md, .codex/project-index.md, .codex/stages/mc2-db696.11/summary.md, docs/plans/quiet-waddling-starfish.md, and docs/plans/career-playbook/* first. Use Beads as source of truth. PR #24-#40 have landed in develop. Important: the primary worktree is dirty on stale feature/career-playbook-library-share; do not discard it. mc2-db696.11.5 schema/read-only/model readiness is advanced and branch codex/career-playbook-live-smoke adds a gated live-smoke runner: default plan mode is non-mutating, mutation-smoke requires token, expected disposable user/org, tRPC URL, dedicated queue, cleanup scope, budget, and explicit confirmation, then emits deterministic evidence and a dry-run cleanup manifest. Continue live mutation smoke only after auth/TOKEN, disposable fixtures, enqueuer/worker queue alignment, cleanup scope, and numeric cost budget gates are explicit. Keep billing/payment out of MVP scope.
 ```
 
 ## Explicit defers
 
-- Real Supabase RLS/staging smoke and authenticated browser e2e share/PDF/worker flow remain tracked under `mc2-db696.11.5` until live-smoke gates are satisfied.
+- Real Supabase RLS/staging smoke and authenticated browser e2e share/PDF/worker flow remain tracked under `mc2-db696.11.5` until live-smoke gates are satisfied; the new runner does not perform cleanup, it only emits an exact dry-run cleanup manifest.
 - 10-concurrent load test remains open under `mc2-db696.11.6`.
 - SSE/subscription status streaming remains deferred; PR #35 intentionally uses polling over the existing tRPC/httpBatchLink transport.

--- a/.codex/stages/mc2-db696.11/artifacts/mc2-db696.11.5-live-runner.md
+++ b/.codex/stages/mc2-db696.11/artifacts/mc2-db696.11.5-live-runner.md
@@ -1,0 +1,123 @@
+---
+schema_version: orchestration-artifact/v1
+artifact_type: local-stage-readiness
+task_id: mc2-db696.11.5
+stage_id: mc2-db696.11
+agent_type: local-orchestrator
+subagent_model: inherit_orchestrator
+reasoning_effort: high
+model_reasoning_rationale: Live-smoke preparation touches auth gates, tRPC flow, worker queue safety, cleanup scope, and paid LLM stop conditions.
+repo: mc2
+branch: codex/career-playbook-live-smoke
+base_branch: origin/develop
+base_commit: cdbe0e8c
+worktree: /home/me/.config/superpowers/worktrees/mc2/career-playbook-live-smoke
+write_zone:
+  - packages/course-gen-platform/src/smoke
+  - packages/course-gen-platform/scripts
+  - packages/course-gen-platform/tests/unit/smoke
+  - docs/career-playbook
+  - docs/superpowers/plans
+  - .codex/stages/mc2-db696.11
+  - .codex/handoff.md
+success_criteria:
+  - Live smoke defaults to a non-mutating plan and reports missing gates.
+  - Mutation smoke requires explicit auth, fixture, queue, cleanup, budget, tRPC, and confirmation gates.
+  - Runner uses product tRPC calls instead of direct Supabase row creation.
+  - Evidence validation covers generated blocks, Mermaid diagrams, anti-goals, decision rows, failure modes, PDF, share, and optional course bridge.
+  - Cleanup manifest is exact, dry-run only, and does not expose bearer tokens.
+selected_docs:
+  - AGENTS.md
+  - .codex/orchestrator.toml
+  - .codex/handoff.md
+  - .codex/project-index.md
+  - .codex/stages/mc2-db696.11/summary.md
+  - docs/plans/quiet-waddling-starfish.md
+  - docs/plans/career-playbook/*
+  - docs/career-playbook/README.md
+  - docs/career-playbook/architecture.md
+  - Context7 tRPC v11 docs
+  - Context7 BullMQ v5 docs
+selected_skills:
+  - orchestrator-stage
+  - task-router
+  - superpowers:brainstorming
+  - superpowers:writing-plans
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+  - run-quality-gate
+  - orchestration-closeout
+  - superpowers:verification-before-completion
+selected_agents:
+  - Boyle visible explorer - backend runner/status transport map
+  - Aquinas visible explorer - cleanup/evidence map
+catalog_candidates:
+  - backend-developer - lookup-only catalog candidate, not promoted
+  - test-engineer - lookup-only catalog candidate, not promoted
+  - bullmq-expert - lookup-only catalog candidate, not promoted
+parallel_group: phase11-live-smoke-runner
+depends_on_streams:
+  - Boyle backend runner map
+  - Aquinas cleanup evidence map
+parallel_decision: local
+status: accepted
+delivery_method: n/a
+accepted_by_orchestrator: yes
+cleanup_status: not_applicable
+cleanup_notes: no live users, rows, jobs, files, workers, cleanup tasks, or LLM calls were created by this implementation
+risk_level: high
+verification:
+  - TDD RED live runner unit: failed on missing env cleanup IDs and evidence failure status before implementation fix
+  - SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key REDIS_URL=redis://127.0.0.1:6379 NODE_ENV=test pnpm --dir packages/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/smoke/career-playbook-live-smoke.test.ts: 8 passed
+  - SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key REDIS_URL=redis://127.0.0.1:6379 NODE_ENV=test pnpm --dir packages/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/smoke/career-playbook-preflight.test.ts tests/unit/smoke/career-playbook-live-smoke.test.ts: 21 passed
+  - pnpm --filter @megacampus/course-gen-platform type-check: passed
+  - direct tsx live runner blocked plan with dedicated queue: status blocked, mutates false, expected missing gates
+  - pnpm --dir packages/course-gen-platform smoke:career-playbook:live all-gates plan with env token: status pass, mutates false, token not printed
+  - git diff --check: passed
+  - python3 scripts/orchestration/validate_artifact.py .codex/stages/mc2-db696.11/artifacts/mc2-db696.11.5-live-runner.md: passed
+  - scripts/orchestration/run_process_verification.sh: passed
+  - pnpm type-check: passed
+  - pnpm lint: passed with existing warnings
+  - SUPABASE_SERVICE_ROLE_KEY=test-service-role NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon pnpm build: passed with existing Next/Supabase Edge Runtime warnings
+changed_files:
+  - .codex/handoff.md
+  - .codex/stages/mc2-db696.11/artifacts/mc2-db696.11.5-live-runner.md
+  - .codex/stages/mc2-db696.11/summary.md
+  - docs/career-playbook/README.md
+  - docs/career-playbook/architecture.md
+  - docs/superpowers/plans/2026-05-21-career-playbook-live-smoke-runner.md
+  - packages/course-gen-platform/package.json
+  - packages/course-gen-platform/scripts/career-playbook-live-smoke.ts
+  - packages/course-gen-platform/src/smoke/career-playbook-live-smoke.ts
+  - packages/course-gen-platform/src/smoke/career-playbook-validation.ts
+  - packages/course-gen-platform/tests/unit/smoke/career-playbook-live-smoke.test.ts
+explicit_defers:
+  - mc2-db696.11.5 remains open for actual live staging mutation smoke because disposable auth fixtures, worker queue alignment, cleanup execution authorization, and numeric API budget are not yet all present
+  - mc2-db696.11.6 remains open for 10-concurrent load testing after a successful single live smoke
+---
+
+# Summary
+
+Prepared the safe runner needed before `mc2-db696.11.5` can execute a real staging mutation smoke.
+
+The new `smoke:career-playbook:live` command has a default `plan` mode that only evaluates gates and prints a report. `mutation-smoke` mode is gated on a bearer token from env, expected disposable user/org IDs, tRPC URL, dedicated non-default queue, cleanup scope, numeric budget, and explicit confirmation. The mutation path uses Career Playbook tRPC procedures instead of writing Supabase rows directly.
+
+# Scope / Routing
+
+Asset Routing: installed orchestration/TDD/verification skills were selected; Boyle and Aquinas provided visible read-only maps; catalog `backend-developer`, `test-engineer`, and `bullmq-expert` remained lookup-only candidates and were not promoted.
+
+Documentation: repo Career Playbook docs plus Context7 tRPC v11 and BullMQ v5 docs were used before implementation. No billing/payment scope was added.
+
+Parallel decision: implementation stayed local after the explorers returned because the remaining write zone was cohesive and shared verification/documentation would have created avoidable conflicts.
+
+# Verification
+
+Targeted unit coverage was added before implementation. The first RED run failed on cleanup IDs resolved only from options and on report status not reflecting failed evidence. After implementation, the live runner unit passed, the combined preflight/live smoke unit suite passed with 21 tests, backend and full repo type-check passed, lint passed with existing warnings, full repo build passed with existing Next/Supabase Edge Runtime warnings, and CLI plan checks showed both blocked missing-gate and all-gates non-mutating reports.
+
+# Delivery / Cleanup
+
+No live tRPC mutation was run, no worker was started, no Redis job was enqueued, no Supabase row was created, and no LLM call was made. The cleanup manifest emitted by the runner is intentionally dry-run only.
+
+# Risks / Follow-ups / Explicit Defers
+
+`mc2-db696.11.5` cannot be closed from this runner alone. The actual live smoke still needs disposable staging auth/user/org fixtures, a queue name used by both API and worker, cleanup execution authorization, and accepted numeric API budget. `mc2-db696.11.6` remains blocked on successful single-smoke readiness.

--- a/.codex/stages/mc2-db696.11/summary.md
+++ b/.codex/stages/mc2-db696.11/summary.md
@@ -141,6 +141,7 @@ Parent `mc2-db696.11` remains `in_progress` because full live staging verificati
 ## PR Readiness Passes
 
 - PR #40 delivered `mc2-db696.11.5` staging schema/read-only/model-routing readiness into `develop`; it does not close live mutation smoke.
+- PR #41 is open from `codex/career-playbook-live-smoke` to `develop` for the gated live-smoke runner; it does not run or close live mutation smoke.
 
 - `mc2-db696.11.7` mapped the original stacked PR delivery path after #37 was opened.
 - PR #24 through #36 and PR #38 have since landed in `develop`; PR #37 is the remaining Phase 11 smoke/preflight delivery PR.

--- a/.codex/stages/mc2-db696.11/summary.md
+++ b/.codex/stages/mc2-db696.11/summary.md
@@ -1,9 +1,9 @@
 # Stage mc2-db696.11 Summary
 
-Status: Phase 11 schema/read-only smoke ready; live mutation smoke still gated
+Status: Phase 11 gated live runner ready; live mutation smoke still gated
 Updated: 2026-05-21
-Branch: `codex/career-playbook-staging-smoke`
-Base: `origin/develop` @ `d92c8c28be3e0a3504a0fb9622d7f3da6229ed6e`
+Branch: `codex/career-playbook-live-smoke`
+Base: `origin/develop` @ `cdbe0e8c`
 
 ## Scope Delivered
 
@@ -40,10 +40,18 @@ Base: `origin/develop` @ `d92c8c28be3e0a3504a0fb9622d7f3da6229ed6e`
   - reran read-only staging preflight successfully with a dedicated non-default queue name
   - configured minimal Career Playbook model routing: MiniMax M2.7 for spec/judge and DeepSeek V4 Flash for follow-up, groups, and regenerator
   - encoded the minimal model routing in migration `20260521101000_allow_career_playbook_model_phases` so future database rebuilds do not depend on manual Supabase rows
+- Prepared gated live-smoke execution for `mc2-db696.11.5`:
+  - added `smoke:career-playbook:live` with default non-mutating plan mode
+  - gated mutation mode behind token, expected disposable user/org, tRPC URL, dedicated queue, cleanup scope, positive budget, and explicit confirmation
+  - kept the runner on product tRPC flow instead of direct Supabase row writes
+  - added deterministic evidence validation for 27 generated blocks, Mermaid coverage, anti-goals, decision rows, failure modes, PDF, public share, and optional course bridge
+  - added exact dry-run cleanup manifest entries for auth user, organization, playbook, BullMQ job, job_status, share slug, bridge course, source documents, and upload paths
+  - documented safe usage in Career Playbook runtime docs and a Superpowers implementation plan
 
 ## Routing And Delegation
 
 - Context7 checked Playwright, Supabase, and Next.js behavior.
+- Context7 checked tRPC v11 and BullMQ v5 behavior for the live runner design.
 - Visible read-only explorers:
   - Raman: web E2E/auth mapping
   - Lagrange: backend/Supabase/Redis smoke mapping
@@ -59,6 +67,8 @@ Base: `origin/develop` @ `d92c8c28be3e0a3504a0fb9622d7f3da6229ed6e`
   - Lovelace: Phase 11 cost-surface map for `mc2-db696.11.4`
   - Helmholtz: Phase 11 live-smoke blocker map for `mc2-db696.11.5`
   - Schrodinger: Phase 11 admin cost evidence endpoint/UI review
+  - Boyle: tRPC/backend runner path and hard-stop gates for `mc2-db696.11.5`
+  - Aquinas: cleanup/evidence map for live-smoke validation and cleanup manifest
 
 The orchestrator did not accept reports blindly. It found and fixed two backend preflight issues before review, then accepted/fixed all review must-fix findings.
 
@@ -77,7 +87,7 @@ Closed in this delivery:
 
 Still open under `mc2-db696.11`:
 
-- `mc2-db696.11.5` - live staging Career Playbook mutation smoke; schema/read-only readiness is done, live generation remains gated on auth fixtures, deployed/local worker queue alignment, cleanup scope, and numeric LLM/API budget
+- `mc2-db696.11.5` - live staging Career Playbook mutation smoke; schema/read-only/model readiness and gated runner are done, live generation remains gated on auth fixtures, deployed/local worker queue alignment, cleanup scope, and numeric LLM/API budget
 - `mc2-db696.11.6` - 10-concurrent load test
 
 Parent `mc2-db696.11` remains `in_progress` because full live staging verification is still blocked by credential, fixture, cleanup, queue-alignment, and cost-budget readiness.
@@ -90,6 +100,13 @@ Parent `mc2-db696.11` remains `in_progress` because full live staging verificati
 - Web config unit: `pnpm --filter @megacampus/web exec vitest run tests/unit/playwright-config.test.ts` - 6 passed.
 - Web cost evidence unit: `pnpm --filter @megacampus/web exec vitest run tests/unit/components/career-playbook/admin-cost-evidence.test.tsx` - 3 passed.
 - Backend type-check: `pnpm --filter @megacampus/course-gen-platform type-check` - passed.
+- Backend smoke units including live runner: `SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key REDIS_URL=redis://127.0.0.1:6379 NODE_ENV=test pnpm --dir packages/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/smoke/career-playbook-preflight.test.ts tests/unit/smoke/career-playbook-live-smoke.test.ts` - 21 passed.
+- Backend type-check after live-runner changes: `pnpm --filter @megacampus/course-gen-platform type-check` - passed.
+- Live runner blocked plan check: direct `tsx scripts/career-playbook-live-smoke.ts --target staging --json` with a dedicated queue printed `status: blocked`, `mutates: false`, and missing live gates as expected.
+- Live runner all-gates plan check: `pnpm --dir packages/course-gen-platform smoke:career-playbook:live --target staging --trpc-url http://127.0.0.1:3001/trpc --expected-user-id ... --expected-organization-id ... --cleanup-scope playbook-and-course --max-cost-usd 3 --confirm-live-mutation --json` with token supplied by env printed `status: pass`, `mutates: false`, and did not expose the token.
+- Full repo type-check after live-runner changes: `pnpm type-check` - passed.
+- Full repo lint after live-runner changes: `pnpm lint` - passed with existing warnings.
+- Full repo build after live-runner changes: `SUPABASE_SERVICE_ROLE_KEY=test-service-role NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon pnpm build` - passed with existing Next/Supabase Edge Runtime warnings.
 - Web type-check: `pnpm --filter @megacampus/web type-check` - passed.
 - Full repo type-check: `pnpm type-check` - passed.
 - Full repo lint: `pnpm lint` - passed with existing warnings only.
@@ -117,6 +134,7 @@ Parent `mc2-db696.11` remains `in_progress` because full live staging verificati
 ## Explicit Defers
 
 - Full live mutation smoke requires disposable user/org/playbooks, dedicated queue alignment between enqueuer and worker, cleanup authorization/scope, valid auth token or storage state, and an accepted numeric API cost budget.
+- The live runner emits cleanup targets but does not delete data; operator cleanup execution remains a separate explicit step after evidence capture.
 - Runtime cost evidence currently records estimated `costUsd: 0`; use admin evidence for payload structure, and capture real provider spend separately unless runtime cost accounting is improved.
 - 10-concurrent load testing remains tracked as an open Beads child and depends on successful live single-smoke readiness.
 

--- a/docs/career-playbook/README.md
+++ b/docs/career-playbook/README.md
@@ -28,6 +28,31 @@ SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABA
 
 Mutation smoke is intentionally not part of the default command. It requires explicit approval, disposable staging fixtures, a dedicated queue, cleanup authorization, and cost-aware LLM credentials.
 
+Live-smoke preparation command:
+
+```bash
+pnpm --dir packages/course-gen-platform smoke:career-playbook:live --target staging --json
+```
+
+The default `plan` mode is non-mutating: it does not call tRPC, enqueue jobs, start workers, write Supabase rows, clean Redis, or call LLMs. A real staging run requires explicit gates:
+
+```bash
+TOKEN="$TOKEN" \
+BULLMQ_QUEUE_NAME=career-playbook-smoke-YYYYMMDD \
+pnpm --dir packages/course-gen-platform smoke:career-playbook:live \
+  --target staging \
+  --mode mutation-smoke \
+  --trpc-url "$CAREER_PLAYBOOK_SMOKE_TRPC_URL" \
+  --expected-user-id "$CAREER_PLAYBOOK_SMOKE_USER_ID" \
+  --expected-organization-id "$CAREER_PLAYBOOK_SMOKE_ORGANIZATION_ID" \
+  --cleanup-scope playbook-and-course \
+  --max-cost-usd 3 \
+  --confirm-live-mutation \
+  --json
+```
+
+Use `--include-course-bridge` only when cleanup covers the created course, generated source documents, upload paths, outbox/jobs, and downstream generation artifacts.
+
 ## Admin Cost Evidence
 
 Career Playbook per-node cost evidence is available to admins at `/admin/generation/career-playbooks/costs`. The page reads `admin.getCareerPlaybookCostEvidence` and shows the filtered playbook count plus page totals and stage/node/model/token/USD rows from `career_playbooks.cost_breakdown`. Invalid cost payloads are marked instead of being treated as verified evidence.
@@ -37,5 +62,7 @@ Career Playbook per-node cost evidence is available to admins at `/admin/generat
 As of 2026-05-20, the Career Playbook migration has been applied to the Supabase project and read-only staging preflight passes when a dedicated non-default queue name is provided. Full mutation smoke is still intentionally gated on disposable staging fixtures, auth token/storage state, queue alignment between enqueuer and worker, cleanup scope, and an accepted numeric LLM/API cost budget.
 
 As of 2026-05-21, minimal model routing for the first live smoke is configured in Supabase and encoded in migration `20260521101000_allow_career_playbook_model_phases`: MiniMax M2.7 for spec/judge and DeepSeek V4 Flash for the remaining Career Playbook phases.
+
+As of 2026-05-21, `smoke:career-playbook:live` provides the gated runner, deterministic evidence validator, and dry-run cleanup manifest needed to run a single live staging smoke once auth fixtures, shared queue alignment, cleanup authorization, and budget are explicit. It does not remove the need for operator approval before live mutation.
 
 See [architecture.md](./architecture.md) for the system map and staging smoke plan.

--- a/docs/career-playbook/architecture.md
+++ b/docs/career-playbook/architecture.md
@@ -57,6 +57,19 @@ Daily staging smoke should run only after staging has the Career Playbook migrat
 
 Staging/prod mutation smoke is blocked unless the current task explicitly approves mutations, cleanup, and expected API cost.
 
+`packages/course-gen-platform/scripts/career-playbook-live-smoke.ts` is the gated live-runner entrypoint. Its default `plan` mode is read-only in practice: it only evaluates gates and prints a report. `mutation-smoke` mode uses real tRPC calls with a disposable bearer token and follows the product flow instead of writing rows directly:
+
+1. `careerPlaybook.session.start`
+2. `careerPlaybook.session.submitAnswer` for fixed sales-manager-b2b answers
+3. `careerPlaybook.generation.requestFollowups`
+4. `careerPlaybook.session.submitAnswer` for follow-up answers/skips
+5. `careerPlaybook.generation.approveAndGenerate`
+6. `careerPlaybook.generation.getStatus` polling until terminal state
+7. `careerPlaybook.library.get`, `exportPdf`, `share.shareToggle`, and `share.getPublicBySlug`
+8. optional `careerPlaybook.courseBridge.createCourseFromPlaybook` only with `--include-course-bridge`
+
+The runner refuses production targets, refuses shared/default `course-generation` for staging, and requires a bearer token, expected disposable user/org IDs, cleanup scope, numeric budget, tRPC URL, and `--confirm-live-mutation`. It emits a dry-run cleanup manifest with exact playbook, BullMQ job, job_status, share slug, course, source document, and upload-path targets; it does not delete anything itself.
+
 ## Cost And Performance Checks
 
 Career Playbook generation records per-node cost in `cost_breakdown` on `career_playbooks`. The admin evidence surface is:

--- a/docs/superpowers/plans/2026-05-21-career-playbook-live-smoke-runner.md
+++ b/docs/superpowers/plans/2026-05-21-career-playbook-live-smoke-runner.md
@@ -1,0 +1,71 @@
+# Career Playbook Live Smoke Runner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a gated Career Playbook live-smoke runner, evidence validator, and dry-run cleanup manifest so `mc2-db696.11.5` can be safely run when staging credentials, fixtures, queue alignment, cleanup scope, and budget are explicit.
+
+**Architecture:** Keep live orchestration in `packages/course-gen-platform/src/smoke/career-playbook-live-smoke.ts`, deterministic content checks in `career-playbook-validation.ts`, and the CLI wrapper in `packages/course-gen-platform/scripts/career-playbook-live-smoke.ts`. The default command is non-mutating; mutation mode requires explicit gates and uses tRPC with a real bearer token rather than direct Supabase row creation.
+
+**Tech Stack:** TypeScript, Vitest, tRPC v11 `createTRPCClient`/`httpBatchLink`, BullMQ v5 read-only job lookup, existing Career Playbook validation helpers.
+
+---
+
+### Task 1: RED Tests
+
+**Files:**
+- Create: `packages/course-gen-platform/tests/unit/smoke/career-playbook-live-smoke.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+  - plan mode reports required gates without calling mutation client methods
+  - staging mutation mode blocks missing token, expected user/org, dedicated queue, cleanup scope, and numeric budget
+  - staging mutation mode rejects the shared `course-generation` queue
+  - validator requires `header` plus `block_1` through `block_26`, required Mermaid diagrams, anti-goals, decision rows, and failure modes
+  - cleanup manifest masks secrets and lists exact playbook/job/course IDs only
+
+- [ ] **Step 2: Verify RED**
+  Run:
+  `pnpm --filter @megacampus/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/smoke/career-playbook-live-smoke.test.ts`
+
+### Task 2: Runner And Validator
+
+**Files:**
+- Create: `packages/course-gen-platform/src/smoke/career-playbook-validation.ts`
+- Create: `packages/course-gen-platform/src/smoke/career-playbook-live-smoke.ts`
+
+- [ ] **Step 1: Implement deterministic validation**
+  Reuse `CAREER_PLAYBOOK_FINAL_BLOCK_ORDER` and `runCareerPlaybookDeterministicChecks`.
+
+- [ ] **Step 2: Implement gate planner**
+  Default to `plan`; require explicit gates for `mutation-smoke`.
+
+- [ ] **Step 3: Implement injectable mutation runner**
+  Use an injected client interface in tests; the real adapter is only created by the CLI.
+
+### Task 3: CLI And Docs
+
+**Files:**
+- Create: `packages/course-gen-platform/scripts/career-playbook-live-smoke.ts`
+- Modify: `packages/course-gen-platform/package.json`
+- Modify: `docs/career-playbook/README.md`
+- Modify: `docs/career-playbook/architecture.md`
+
+- [ ] **Step 1: Add CLI parser**
+  Support `--target`, `--mode`, `--trpc-url`, `--expected-user-id`, `--expected-organization-id`, `--max-cost-usd`, `--cleanup-scope`, `--confirm-live-mutation`, `--json`. Read the bearer token only from `TOKEN` or `CAREER_PLAYBOOK_SMOKE_TOKEN` so package-manager command echo cannot leak it.
+
+- [ ] **Step 2: Add package script**
+  Add `smoke:career-playbook:live`.
+
+- [ ] **Step 3: Document safe usage**
+  State that default mode is non-mutating and live mode needs explicit approval.
+
+### Task 4: Verification And Handoff
+
+**Files:**
+- Modify: `.codex/handoff.md`
+- Create/update: `.codex/stages/mc2-db696.11/artifacts/mc2-db696.11.5-live-runner.md`
+- Modify: `.codex/stages/mc2-db696.11/summary.md`
+
+- [ ] **Step 1: Run targeted unit tests**
+- [ ] **Step 2: Run `git diff --check`, process verification, and stage artifact validation**
+- [ ] **Step 3: Update Beads and handoff**
+- [ ] **Step 4: Commit and push the feature branch**

--- a/packages/course-gen-platform/package.json
+++ b/packages/course-gen-platform/package.json
@@ -48,7 +48,8 @@
     "type-check": "pnpm --filter @megacampus/shared-logger build && pnpm --filter @megacampus/shared-types exec tsc --build --force && pnpm --filter @megacampus/shared-utils build && tsc --noEmit",
     "analyze:bundle": "tsx scripts/analyze-processor-bundle.ts",
     "benchmark-llm": "tsx scripts/benchmark-llm/index.ts",
-    "smoke:career-playbook:preflight": "TMPDIR=${TMPDIR:-/tmp} tsx scripts/career-playbook-smoke-preflight.ts"
+    "smoke:career-playbook:preflight": "TMPDIR=${TMPDIR:-/tmp} tsx scripts/career-playbook-smoke-preflight.ts",
+    "smoke:career-playbook:live": "TMPDIR=${TMPDIR:-/tmp} tsx scripts/career-playbook-live-smoke.ts"
   },
   "dependencies": {
     "@bull-board/api": "^5.14.0",

--- a/packages/course-gen-platform/scripts/career-playbook-live-smoke.ts
+++ b/packages/course-gen-platform/scripts/career-playbook-live-smoke.ts
@@ -1,0 +1,223 @@
+import 'dotenv/config';
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import type { AppRouter } from '../src/server/app-router';
+import {
+  type CareerPlaybookCleanupScope,
+  type CareerPlaybookLiveSmokeClient,
+  type CareerPlaybookLiveSmokeMode,
+  type CareerPlaybookLiveSmokeTarget,
+  formatCareerPlaybookLiveSmokeReport,
+  runCareerPlaybookLiveSmoke,
+} from '../src/smoke/career-playbook-live-smoke';
+
+interface ParsedArgs {
+  mode: CareerPlaybookLiveSmokeMode;
+  targetEnvironment?: CareerPlaybookLiveSmokeTarget;
+  trpcUrl?: string;
+  expectedUserId?: string;
+  expectedOrganizationId?: string;
+  queueName?: string;
+  cleanupScope?: CareerPlaybookCleanupScope;
+  maxCostUsd?: number;
+  confirmLiveMutation: boolean;
+  includeCourseBridge: boolean;
+  json: boolean;
+}
+
+const TARGETS = ['local', 'development', 'dev', 'staging', 'production', 'prod'] as const;
+const CLEANUP_SCOPES = ['playbook-only', 'playbook-and-course'] as const;
+
+function printUsage(): void {
+  console.log(`Usage: pnpm --dir packages/course-gen-platform smoke:career-playbook:live [options]
+
+Options:
+  --mode <plan|mutation-smoke>            Runner mode (default: plan)
+  --target <local|development|dev|staging|production|prod>
+                                           Target environment label
+  --trpc-url <url>                         Backend tRPC URL, for example https://api.example.com/trpc
+  --expected-user-id <uuid>                Disposable user id expected in staging
+  --expected-organization-id <uuid>        Disposable organization id expected in staging
+  --queue <name>                           Dedicated BULLMQ_QUEUE_NAME used by API and worker
+  --cleanup-scope <playbook-only|playbook-and-course>
+                                           Exact cleanup scope after evidence capture
+  --max-cost-usd <number>                  Numeric API/LLM budget cap for this run
+  --confirm-live-mutation                  Required for mutation-smoke
+  --include-course-bridge                  Also create the bridge course; requires cleanup coverage
+  --json                                   Print JSON report
+  -h, --help                               Show help
+
+Default plan mode does not call tRPC, enqueue jobs, start workers, write Supabase rows,
+clean Redis, or call LLMs. Mutation mode reads the bearer token from TOKEN or
+CAREER_PLAYBOOK_SMOKE_TOKEN; do not pass secrets as CLI arguments because package
+managers can echo them. Mutation mode should only be used with disposable staging
+fixtures, a dedicated queue, cleanup authorization, and a budget.`);
+}
+
+function readValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseTarget(value: string): CareerPlaybookLiveSmokeTarget {
+  if ((TARGETS as readonly string[]).includes(value)) return value as CareerPlaybookLiveSmokeTarget;
+  throw new Error('--target must be local, development, dev, staging, production, or prod');
+}
+
+function parseCleanupScope(value: string): CareerPlaybookCleanupScope {
+  if ((CLEANUP_SCOPES as readonly string[]).includes(value)) {
+    return value as CareerPlaybookCleanupScope;
+  }
+  throw new Error('--cleanup-scope must be playbook-only or playbook-and-course');
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    mode: 'plan',
+    confirmLiveMutation: false,
+    includeCourseBridge: false,
+    json: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case '--mode': {
+        const value = readValue(argv, index, arg);
+        if (value !== 'plan' && value !== 'mutation-smoke') {
+          throw new Error('--mode must be plan or mutation-smoke');
+        }
+        parsed.mode = value;
+        index += 1;
+        break;
+      }
+      case '--target':
+        parsed.targetEnvironment = parseTarget(readValue(argv, index, arg));
+        index += 1;
+        break;
+      case '--trpc-url':
+        parsed.trpcUrl = readValue(argv, index, arg);
+        index += 1;
+        break;
+      case '--expected-user-id':
+        parsed.expectedUserId = readValue(argv, index, arg);
+        index += 1;
+        break;
+      case '--expected-organization-id':
+        parsed.expectedOrganizationId = readValue(argv, index, arg);
+        index += 1;
+        break;
+      case '--queue':
+        parsed.queueName = readValue(argv, index, arg);
+        index += 1;
+        break;
+      case '--cleanup-scope':
+        parsed.cleanupScope = parseCleanupScope(readValue(argv, index, arg));
+        index += 1;
+        break;
+      case '--max-cost-usd': {
+        const value = Number(readValue(argv, index, arg));
+        if (!Number.isFinite(value) || value <= 0) {
+          throw new Error('--max-cost-usd must be a positive number');
+        }
+        parsed.maxCostUsd = value;
+        index += 1;
+        break;
+      }
+      case '--confirm-live-mutation':
+        parsed.confirmLiveMutation = true;
+        break;
+      case '--include-course-bridge':
+        parsed.includeCourseBridge = true;
+        break;
+      case '--json':
+        parsed.json = true;
+        break;
+      case '-h':
+      case '--help':
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function createTrpcLiveSmokeClient(trpcUrl: string, token: string): CareerPlaybookLiveSmokeClient {
+  const trpc = createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: trpcUrl,
+        headers() {
+          return {
+            Authorization: `Bearer ${token}`,
+          };
+        },
+      }),
+    ],
+  });
+
+  return {
+    startSession: input => trpc.careerPlaybook.session.start.mutate(input),
+    submitAnswer: input => trpc.careerPlaybook.session.submitAnswer.mutate(input),
+    requestFollowups: input => trpc.careerPlaybook.generation.requestFollowups.mutate(input),
+    approveAndGenerate: input => trpc.careerPlaybook.generation.approveAndGenerate.mutate(input),
+    getStatus: input => trpc.careerPlaybook.generation.getStatus.query(input),
+    getLibraryDetail: input => trpc.careerPlaybook.library.get.query(input),
+    exportPdf: input => trpc.careerPlaybook.exportPdf.query(input),
+    toggleShare: input => trpc.careerPlaybook.share.shareToggle.mutate(input),
+    getPublicShare: input => trpc.careerPlaybook.share.getPublicBySlug.query(input),
+    createCourseFromPlaybook: input =>
+      trpc.careerPlaybook.courseBridge.createCourseFromPlaybook.mutate(input),
+  };
+}
+
+function exitCodeFor(status: string): number {
+  if (status === 'pass' || status === 'warn') return 0;
+  if (status === 'blocked') return 2;
+  return 1;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const token = process.env.TOKEN ?? process.env.CAREER_PLAYBOOK_SMOKE_TOKEN;
+  const trpcUrl = args.trpcUrl ?? process.env.CAREER_PLAYBOOK_SMOKE_TRPC_URL;
+  const client =
+    args.mode === 'mutation-smoke' && token && trpcUrl
+      ? createTrpcLiveSmokeClient(trpcUrl, token)
+      : undefined;
+  const report = await runCareerPlaybookLiveSmoke(
+    {
+      mode: args.mode,
+      targetEnvironment: args.targetEnvironment,
+      env: {
+        ...process.env,
+        BULLMQ_QUEUE_NAME: args.queueName ?? process.env.BULLMQ_QUEUE_NAME,
+      },
+      trpcUrl,
+      token,
+      expectedUserId: args.expectedUserId,
+      expectedOrganizationId: args.expectedOrganizationId,
+      queueName: args.queueName,
+      cleanupScope: args.cleanupScope,
+      maxCostUsd: args.maxCostUsd,
+      confirmLiveMutation: args.confirmLiveMutation,
+      includeCourseBridge: args.includeCourseBridge,
+    },
+    { client }
+  );
+
+  console.log(args.json ? JSON.stringify(report, null, 2) : formatCareerPlaybookLiveSmokeReport(report));
+  process.exit(exitCodeFor(report.status));
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/packages/course-gen-platform/src/smoke/career-playbook-live-smoke.ts
+++ b/packages/course-gen-platform/src/smoke/career-playbook-live-smoke.ts
@@ -1,0 +1,648 @@
+import type {
+  CareerPlaybookAnswerSubmission,
+  CareerPlaybookFixedAnswer,
+  CareerPlaybookFollowupAnswer,
+  CareerPlaybookFollowupQuestion,
+  CareerPlaybookBlockId,
+  CareerPlaybookBlockState,
+  CareerPlaybookPlaybookStatus,
+  Language,
+} from '@megacampus/shared-types';
+import {
+  validateCareerPlaybookSmokeEvidence,
+  type CareerPlaybookSmokeEvidenceReport,
+} from './career-playbook-validation';
+
+export type CareerPlaybookLiveSmokeMode = 'plan' | 'mutation-smoke';
+export type CareerPlaybookLiveSmokeTarget =
+  | 'local'
+  | 'development'
+  | 'dev'
+  | 'staging'
+  | 'production'
+  | 'prod';
+export type CareerPlaybookLiveSmokeStatus = 'pass' | 'warn' | 'blocked' | 'skipped';
+export type CareerPlaybookLiveSmokeReportStatus = 'pass' | 'warn' | 'blocked' | 'fail';
+export type CareerPlaybookCleanupScope = 'playbook-only' | 'playbook-and-course';
+
+export interface CareerPlaybookLiveSmokeEnv {
+  [key: string]: string | undefined;
+}
+
+export interface CareerPlaybookLiveSmokeOptions {
+  mode?: CareerPlaybookLiveSmokeMode;
+  targetEnvironment?: CareerPlaybookLiveSmokeTarget;
+  env?: CareerPlaybookLiveSmokeEnv;
+  trpcUrl?: string;
+  token?: string;
+  expectedUserId?: string;
+  expectedOrganizationId?: string;
+  queueName?: string;
+  cleanupScope?: CareerPlaybookCleanupScope;
+  maxCostUsd?: number;
+  confirmLiveMutation?: boolean;
+  runId?: string;
+  pollTimeoutMs?: number;
+  pollIntervalMs?: number;
+  includeCourseBridge?: boolean;
+}
+
+export interface CareerPlaybookLiveSmokeCheck {
+  id: string;
+  status: CareerPlaybookLiveSmokeStatus;
+  mutates: boolean;
+  note: string;
+}
+
+export interface CareerPlaybookLiveSmokePlan {
+  mode: CareerPlaybookLiveSmokeMode;
+  targetEnvironment: CareerPlaybookLiveSmokeTarget;
+  status: 'pass' | 'blocked' | 'warn';
+  mutates: boolean;
+  checks: CareerPlaybookLiveSmokeCheck[];
+}
+
+export interface CareerPlaybookLiveSmokeReport extends Omit<CareerPlaybookLiveSmokePlan, 'status'> {
+  status: CareerPlaybookLiveSmokeReportStatus;
+  playbookId?: string;
+  courseId?: string;
+  cleanupManifest?: CareerPlaybookCleanupManifest;
+  evidence?: CareerPlaybookSmokeEvidenceReport;
+}
+
+export interface CareerPlaybookLiveSmokeSessionResponse {
+  playbookId: string;
+  status: CareerPlaybookPlaybookStatus;
+}
+
+export interface CareerPlaybookLiveSmokeFollowupResponse {
+  questions: CareerPlaybookFollowupQuestion[];
+  completeness_score: number;
+  stop_recommendation: 'ask_more' | 'ready_to_generate';
+}
+
+export interface CareerPlaybookLiveSmokeGenerationStatus {
+  playbookId: string;
+  status: CareerPlaybookPlaybookStatus;
+  progress?: number;
+  finalMarkdown?: string;
+  completedAt?: string;
+  generatedBlocks?: unknown;
+}
+
+export interface CareerPlaybookLiveSmokeLibraryDetail {
+  id: string;
+  status: CareerPlaybookPlaybookStatus;
+  finalMarkdown: string | null;
+  generatedBlocks: Partial<Record<CareerPlaybookBlockId, CareerPlaybookBlockState>>;
+  completedAt?: string | null;
+}
+
+export interface CareerPlaybookLiveSmokeClient {
+  startSession: (input: { language: Language }) => Promise<CareerPlaybookLiveSmokeSessionResponse>;
+  submitAnswer: (input: {
+    playbookId: string;
+    phase: 'fixed' | 'followup' | 'freeform';
+    answer: CareerPlaybookAnswerSubmission;
+  }) => Promise<unknown>;
+  requestFollowups: (input: {
+    playbookId: string;
+    fixedAnswers: Record<string, CareerPlaybookFixedAnswer>;
+    followupAnswers: Record<string, CareerPlaybookFollowupAnswer>;
+    contentLanguage: Language;
+  }) => Promise<CareerPlaybookLiveSmokeFollowupResponse>;
+  approveAndGenerate: (input: {
+    playbookId: string;
+  }) => Promise<CareerPlaybookLiveSmokeGenerationStatus>;
+  getStatus: (input: { playbookId: string }) => Promise<CareerPlaybookLiveSmokeGenerationStatus>;
+  getLibraryDetail: (input: { playbookId: string }) => Promise<CareerPlaybookLiveSmokeLibraryDetail>;
+  exportPdf: (input: { playbookId: string }) => Promise<unknown>;
+  toggleShare: (input: {
+    playbookId: string;
+    isPublic: boolean;
+  }) => Promise<{ shareSlug: string | null; isPublic: boolean }>;
+  getPublicShare: (input: { shareSlug: string }) => Promise<unknown>;
+  createCourseFromPlaybook: (input: {
+    playbookId: string;
+    includeWebResearch: boolean;
+  }) => Promise<{ courseId: string; redirectUrl: string; sourceDocumentIds: string[] }>;
+}
+
+export interface CareerPlaybookLiveSmokeDependencies {
+  client?: CareerPlaybookLiveSmokeClient;
+  now?: () => Date;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export type CareerPlaybookCleanupItemType =
+  | 'auth_user'
+  | 'organization'
+  | 'career_playbook'
+  | 'bullmq_job'
+  | 'job_status'
+  | 'share_slug'
+  | 'course'
+  | 'source_document'
+  | 'upload_path';
+
+export interface CareerPlaybookCleanupItem {
+  type: CareerPlaybookCleanupItemType;
+  id: string;
+  note: string;
+}
+
+export interface CareerPlaybookCleanupManifestInput {
+  runId: string;
+  targetEnvironment: CareerPlaybookLiveSmokeTarget;
+  queueName?: string;
+  token?: string;
+  expectedUserId?: string;
+  expectedOrganizationId?: string;
+  playbookId?: string;
+  careerPlaybookJobId?: string;
+  shareSlug?: string | null;
+  courseId?: string | null;
+  sourceDocumentIds?: string[];
+  uploadPaths?: string[];
+}
+
+export interface CareerPlaybookCleanupManifest {
+  runId: string;
+  targetEnvironment: CareerPlaybookLiveSmokeTarget;
+  queueName?: string;
+  mutates: false;
+  items: CareerPlaybookCleanupItem[];
+}
+
+const DEFAULT_QUEUE_NAME = 'course-generation';
+const DEFAULT_POLL_TIMEOUT_MS = 20 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+
+const SALES_MANAGER_B2B_FIXED_ANSWERS: CareerPlaybookFixedAnswer[] = [
+  { question_key: 'position', value: 'Sales Manager B2B' },
+  { question_key: 'department', value: 'sales' },
+  { question_key: 'level', value: 'lead' },
+  { question_key: 'reporting', value: 'Reports to CRO. Leads SDR and AE team.' },
+  { question_key: 'team_size', value: '51-200' },
+  { question_key: 'company_stage', value: 'growth' },
+  { question_key: 'content_language', value: 'en' },
+];
+
+function hasValue(value: string | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function normalizeMode(mode: CareerPlaybookLiveSmokeOptions['mode']): CareerPlaybookLiveSmokeMode {
+  return mode ?? 'plan';
+}
+
+function normalizeTarget(
+  targetEnvironment: CareerPlaybookLiveSmokeOptions['targetEnvironment'],
+  env: CareerPlaybookLiveSmokeEnv
+): CareerPlaybookLiveSmokeTarget {
+  if (targetEnvironment) return targetEnvironment;
+  if (env.NODE_ENV === 'production') return 'prod';
+  if (env.NODE_ENV === 'development') return 'development';
+  return 'local';
+}
+
+function isProductionTarget(targetEnvironment: CareerPlaybookLiveSmokeTarget): boolean {
+  return targetEnvironment === 'production' || targetEnvironment === 'prod';
+}
+
+function isStagingOrProduction(targetEnvironment: CareerPlaybookLiveSmokeTarget): boolean {
+  return ['staging', 'production', 'prod'].includes(targetEnvironment);
+}
+
+function resolveToken(options: CareerPlaybookLiveSmokeOptions, env: CareerPlaybookLiveSmokeEnv) {
+  return options.token ?? env.TOKEN ?? env.CAREER_PLAYBOOK_SMOKE_TOKEN;
+}
+
+function resolveQueueName(options: CareerPlaybookLiveSmokeOptions, env: CareerPlaybookLiveSmokeEnv) {
+  return options.queueName ?? env.BULLMQ_QUEUE_NAME ?? DEFAULT_QUEUE_NAME;
+}
+
+function resolveMaxCostUsd(
+  options: CareerPlaybookLiveSmokeOptions,
+  env: CareerPlaybookLiveSmokeEnv
+): number | undefined {
+  if (typeof options.maxCostUsd === 'number') return options.maxCostUsd;
+  if (!hasValue(env.CAREER_PLAYBOOK_SMOKE_MAX_COST_USD)) return undefined;
+  const parsed = Number(env.CAREER_PLAYBOOK_SMOKE_MAX_COST_USD);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function resolveCleanupScope(
+  options: CareerPlaybookLiveSmokeOptions,
+  env: CareerPlaybookLiveSmokeEnv
+): CareerPlaybookCleanupScope | undefined {
+  const value = options.cleanupScope ?? env.CAREER_PLAYBOOK_SMOKE_CLEANUP_SCOPE;
+  if (value === 'playbook-only' || value === 'playbook-and-course') return value;
+  return undefined;
+}
+
+function check(
+  id: string,
+  status: CareerPlaybookLiveSmokeStatus,
+  mutates: boolean,
+  note: string
+): CareerPlaybookLiveSmokeCheck {
+  return { id, status, mutates, note };
+}
+
+function summarizePlan(checks: CareerPlaybookLiveSmokeCheck[]): CareerPlaybookLiveSmokePlan['status'] {
+  if (checks.some(item => item.status === 'blocked')) return 'blocked';
+  if (checks.some(item => item.status === 'warn')) return 'warn';
+  return 'pass';
+}
+
+function requireGate(
+  id: string,
+  present: boolean,
+  noteWhenPresent: string,
+  noteWhenMissing: string
+): CareerPlaybookLiveSmokeCheck {
+  return check(id, present ? 'pass' : 'blocked', false, present ? noteWhenPresent : noteWhenMissing);
+}
+
+export function buildCareerPlaybookLiveSmokePlan(
+  options: CareerPlaybookLiveSmokeOptions = {}
+): CareerPlaybookLiveSmokePlan {
+  const env = options.env ?? process.env;
+  const mode = normalizeMode(options.mode);
+  const targetEnvironment = normalizeTarget(options.targetEnvironment, env);
+  const token = resolveToken(options, env);
+  const queueName = resolveQueueName(options, env);
+  const maxCostUsd = resolveMaxCostUsd(options, env);
+  const cleanupScope = resolveCleanupScope(options, env);
+  const trpcUrl = options.trpcUrl ?? env.CAREER_PLAYBOOK_SMOKE_TRPC_URL;
+  const expectedUserId = options.expectedUserId ?? env.CAREER_PLAYBOOK_SMOKE_USER_ID;
+  const expectedOrganizationId =
+    options.expectedOrganizationId ?? env.CAREER_PLAYBOOK_SMOKE_ORGANIZATION_ID;
+
+  const checks: CareerPlaybookLiveSmokeCheck[] = [
+    check(
+      'mode',
+      mode === 'plan' ? 'skipped' : 'pass',
+      mode === 'mutation-smoke',
+      mode === 'plan'
+        ? 'Plan mode is non-mutating and will not call tRPC, enqueue jobs, start workers, or call LLMs.'
+        : 'Mutation mode selected; live smoke gates must all pass before any tRPC mutation.'
+    ),
+    check(
+      'target-environment',
+      isProductionTarget(targetEnvironment) ? 'blocked' : 'pass',
+      false,
+      isProductionTarget(targetEnvironment)
+        ? 'Production Career Playbook live smoke is blocked by this runner.'
+        : `Target environment is ${targetEnvironment}.`
+    ),
+    requireGate(
+      'trpc-url',
+      hasValue(trpcUrl),
+      'tRPC URL supplied.',
+      'Set --trpc-url or CAREER_PLAYBOOK_SMOKE_TRPC_URL before live mutation smoke.'
+    ),
+    requireGate(
+      'auth-token',
+      hasValue(token),
+      'Bearer token supplied without exposing it in the report.',
+      'Set TOKEN or CAREER_PLAYBOOK_SMOKE_TOKEN for the disposable staging user.'
+    ),
+    requireGate(
+      'expected-user-id',
+      hasValue(expectedUserId),
+      'Expected disposable user id supplied.',
+      'Set --expected-user-id or CAREER_PLAYBOOK_SMOKE_USER_ID.'
+    ),
+    requireGate(
+      'expected-organization-id',
+      hasValue(expectedOrganizationId),
+      'Expected disposable organization id supplied.',
+      'Set --expected-organization-id or CAREER_PLAYBOOK_SMOKE_ORGANIZATION_ID.'
+    ),
+    check(
+      'dedicated-queue',
+      queueName !== DEFAULT_QUEUE_NAME && hasValue(queueName)
+        ? 'pass'
+        : isStagingOrProduction(targetEnvironment)
+          ? 'blocked'
+          : 'warn',
+      false,
+      queueName !== DEFAULT_QUEUE_NAME && hasValue(queueName)
+        ? `Dedicated queue selected: ${queueName}.`
+        : 'Live staging/prod smoke requires a dedicated non-default BULLMQ_QUEUE_NAME before enqueue.'
+    ),
+    requireGate(
+      'cleanup-scope',
+      cleanupScope !== undefined,
+      `Cleanup scope supplied: ${cleanupScope}.`,
+      'Set --cleanup-scope to playbook-only or playbook-and-course before live mutation smoke.'
+    ),
+    requireGate(
+      'max-cost-usd',
+      typeof maxCostUsd === 'number' && maxCostUsd > 0,
+      `Max live-smoke budget supplied: ${maxCostUsd} USD.`,
+      'Set a positive --max-cost-usd or CAREER_PLAYBOOK_SMOKE_MAX_COST_USD.'
+    ),
+    requireGate(
+      'confirm-live-mutation',
+      options.confirmLiveMutation === true,
+      'Explicit live mutation confirmation supplied.',
+      'Pass --confirm-live-mutation for mutation-smoke mode.'
+    ),
+  ];
+
+  return {
+    mode,
+    targetEnvironment,
+    status: summarizePlan(checks),
+    mutates: mode === 'mutation-smoke',
+    checks,
+  };
+}
+
+function fixedAnswerRecord(): Record<string, CareerPlaybookFixedAnswer> {
+  return Object.fromEntries(
+    SALES_MANAGER_B2B_FIXED_ANSWERS.map(answer => [answer.question_key, answer])
+  );
+}
+
+function followupAnswerFor(question: CareerPlaybookFollowupQuestion): CareerPlaybookAnswerSubmission {
+  if (question.options?.[0]?.value) {
+    return {
+      question_id: question.question_id,
+      value: question.options[0].value,
+    };
+  }
+
+  return {
+    question_id: question.question_id,
+    skipped: true,
+  };
+}
+
+function isPdfExportResponse(value: unknown): value is {
+  pdfBase64: string;
+  contentType: string;
+  sizeBytes: number;
+} {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.pdfBase64 === 'string' &&
+    typeof candidate.contentType === 'string' &&
+    typeof candidate.sizeBytes === 'number'
+  );
+}
+
+function pdfStartsWithHeader(pdfBase64: string): boolean {
+  try {
+    return Buffer.from(pdfBase64, 'base64').subarray(0, 4).toString('utf8') === '%PDF';
+  } catch {
+    return false;
+  }
+}
+
+async function waitForCompletion(
+  client: CareerPlaybookLiveSmokeClient,
+  playbookId: string,
+  options: CareerPlaybookLiveSmokeOptions,
+  dependencies: CareerPlaybookLiveSmokeDependencies
+): Promise<CareerPlaybookLiveSmokeGenerationStatus> {
+  const now = dependencies.now ?? (() => new Date());
+  const sleep = dependencies.sleep ?? (ms => new Promise<void>(resolve => setTimeout(resolve, ms)));
+  const timeoutMs = options.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+  const intervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const startedAt = now().getTime();
+
+  while (now().getTime() - startedAt <= timeoutMs) {
+    const status = await client.getStatus({ playbookId });
+    if (status.status === 'completed' || status.status === 'failed') return status;
+    await sleep(intervalMs);
+  }
+
+  throw new Error(`Career Playbook live smoke timed out waiting for ${playbookId}`);
+}
+
+export async function runCareerPlaybookLiveSmoke(
+  options: CareerPlaybookLiveSmokeOptions = {},
+  dependencies: CareerPlaybookLiveSmokeDependencies = {}
+): Promise<CareerPlaybookLiveSmokeReport> {
+  const plan = buildCareerPlaybookLiveSmokePlan(options);
+  const env = options.env ?? process.env;
+  const expectedUserId = options.expectedUserId ?? env.CAREER_PLAYBOOK_SMOKE_USER_ID;
+  const expectedOrganizationId =
+    options.expectedOrganizationId ?? env.CAREER_PLAYBOOK_SMOKE_ORGANIZATION_ID;
+
+  if (plan.mode === 'plan' || plan.status !== 'pass') {
+    return { ...plan, mutates: false };
+  }
+
+  const client = dependencies.client;
+  if (!client) {
+    return {
+      ...plan,
+      status: 'blocked',
+      checks: [
+        ...plan.checks,
+        check('client', 'blocked', false, 'No tRPC client adapter was supplied.'),
+      ],
+    };
+  }
+
+  const session = await client.startSession({ language: 'en' });
+  const playbookId = session.playbookId;
+
+  for (const fixedAnswer of SALES_MANAGER_B2B_FIXED_ANSWERS) {
+    await client.submitAnswer({
+      playbookId,
+      phase: 'fixed',
+      answer: {
+        question_key: fixedAnswer.question_key,
+        value: fixedAnswer.value,
+      },
+    });
+  }
+
+  const followups = await client.requestFollowups({
+    playbookId,
+    fixedAnswers: fixedAnswerRecord(),
+    followupAnswers: {},
+    contentLanguage: 'en',
+  });
+
+  for (const question of followups.questions) {
+    await client.submitAnswer({
+      playbookId,
+      phase: 'followup',
+      answer: followupAnswerFor(question),
+    });
+  }
+
+  await client.approveAndGenerate({ playbookId });
+  await waitForCompletion(client, playbookId, options, dependencies);
+  const detail = await client.getLibraryDetail({ playbookId });
+  const pdf = await client.exportPdf({ playbookId });
+  const pdfEvidence = isPdfExportResponse(pdf)
+    ? {
+        contentType: pdf.contentType,
+        sizeBytes: pdf.sizeBytes,
+        startsWithPdfHeader: pdfStartsWithHeader(pdf.pdfBase64),
+      }
+    : undefined;
+  const share = await client.toggleShare({ playbookId, isPublic: true });
+  if (share.shareSlug) {
+    await client.getPublicShare({ shareSlug: share.shareSlug });
+  }
+
+  let courseId: string | undefined;
+  let sourceDocumentIds: string[] = [];
+  let redirectUrl: string | undefined;
+  if (options.includeCourseBridge) {
+    const course = await client.createCourseFromPlaybook({
+      playbookId,
+      includeWebResearch: false,
+    });
+    courseId = course.courseId;
+    sourceDocumentIds = course.sourceDocumentIds;
+    redirectUrl = course.redirectUrl;
+  }
+
+  const evidence = validateCareerPlaybookSmokeEvidence({
+    playbook: {
+      id: detail.id,
+      status: detail.status,
+      completedAt: detail.completedAt,
+      generatedBlocks: detail.generatedBlocks,
+      finalMarkdown: detail.finalMarkdown,
+    },
+    pdf: pdfEvidence,
+    share: {
+      isPublic: share.isPublic,
+      shareSlug: share.shareSlug,
+      publicFetchOk: Boolean(share.shareSlug),
+    },
+    courseBridge: options.includeCourseBridge
+      ? {
+          courseId,
+          redirectUrl,
+          sourceDocumentIds,
+        }
+      : undefined,
+    requireSurfaces: true,
+    requireCourseBridge: options.includeCourseBridge === true,
+  });
+
+  return {
+    ...plan,
+    status: evidence.status === 'pass' ? plan.status : 'fail',
+    playbookId,
+    courseId,
+    evidence,
+    cleanupManifest: buildCareerPlaybookCleanupManifest({
+      runId: options.runId ?? `career-playbook-smoke-${new Date().toISOString()}`,
+      targetEnvironment: plan.targetEnvironment,
+      queueName: resolveQueueName(options, options.env ?? process.env),
+      expectedUserId,
+      expectedOrganizationId,
+      playbookId,
+      careerPlaybookJobId: `career-playbook:${playbookId}`,
+      shareSlug: share.shareSlug,
+      courseId,
+      sourceDocumentIds,
+    }),
+  };
+}
+
+function pushCleanupItem(
+  items: CareerPlaybookCleanupItem[],
+  type: CareerPlaybookCleanupItemType,
+  id: string | null | undefined,
+  note: string
+): void {
+  if (!hasValue(id ?? undefined)) return;
+  items.push({ type, id: id as string, note });
+}
+
+export function buildCareerPlaybookCleanupManifest(
+  input: CareerPlaybookCleanupManifestInput
+): CareerPlaybookCleanupManifest {
+  const items: CareerPlaybookCleanupItem[] = [];
+
+  pushCleanupItem(items, 'auth_user', input.expectedUserId, 'Delete only if this user is disposable.');
+  pushCleanupItem(
+    items,
+    'organization',
+    input.expectedOrganizationId,
+    'Delete only if this organization is disposable.'
+  );
+  pushCleanupItem(items, 'career_playbook', input.playbookId, 'Delete by exact playbook id.');
+  pushCleanupItem(
+    items,
+    'bullmq_job',
+    input.careerPlaybookJobId,
+    'Remove only from the dedicated Career Playbook smoke queue.'
+  );
+  pushCleanupItem(
+    items,
+    'job_status',
+    input.careerPlaybookJobId,
+    'Delete job_status by exact job_id because Career Playbook jobs have no course_id.'
+  );
+  pushCleanupItem(items, 'share_slug', input.shareSlug, 'Share state lives on the playbook row.');
+  pushCleanupItem(items, 'course', input.courseId, 'Delete bridge course after file/job cleanup.');
+
+  for (const documentId of input.sourceDocumentIds ?? []) {
+    pushCleanupItem(items, 'source_document', documentId, 'Delete bridge source document by exact id.');
+  }
+
+  for (const uploadPath of input.uploadPaths ?? []) {
+    pushCleanupItem(items, 'upload_path', uploadPath, 'Remove exact generated upload path.');
+  }
+
+  return {
+    runId: input.runId,
+    targetEnvironment: input.targetEnvironment,
+    queueName: input.queueName,
+    mutates: false,
+    items,
+  };
+}
+
+export function formatCareerPlaybookLiveSmokeReport(report: CareerPlaybookLiveSmokeReport): string {
+  const lines = [
+    'Career Playbook live smoke runner',
+    `mode: ${report.mode}`,
+    `target: ${report.targetEnvironment}`,
+    `status: ${report.status}`,
+    `mutates: ${report.mutates}`,
+    '',
+    'Checks:',
+  ];
+
+  for (const check of report.checks) {
+    lines.push(`- ${check.id}: ${check.status} [mutates=${check.mutates}] - ${check.note}`);
+  }
+
+  if (report.playbookId) {
+    lines.push('', `playbookId: ${report.playbookId}`);
+  }
+  if (report.courseId) {
+    lines.push(`courseId: ${report.courseId}`);
+  }
+  if (report.evidence) {
+    lines.push('', `Evidence: ${report.evidence.status}`);
+    for (const check of report.evidence.checks) {
+      lines.push(`- ${check.id}: ${check.status} - ${check.note}`);
+    }
+  }
+  if (report.cleanupManifest) {
+    lines.push('', 'Cleanup manifest (dry-run):');
+    for (const item of report.cleanupManifest.items) {
+      lines.push(`- ${item.type}: ${item.id} - ${item.note}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/packages/course-gen-platform/src/smoke/career-playbook-validation.ts
+++ b/packages/course-gen-platform/src/smoke/career-playbook-validation.ts
@@ -1,0 +1,309 @@
+import type {
+  CareerPlaybookBlockId,
+  CareerPlaybookBlockState,
+  CareerPlaybookPlaybookStatus,
+} from '@megacampus/shared-types';
+import { CAREER_PLAYBOOK_FINAL_BLOCK_ORDER } from '@/stages/stage-career-playbook/nodes/final-assembler';
+
+export type CareerPlaybookSmokeEvidenceStatus = 'pass' | 'fail' | 'skipped';
+
+export interface CareerPlaybookSmokeEvidenceCheck {
+  id: string;
+  status: CareerPlaybookSmokeEvidenceStatus;
+  note: string;
+}
+
+export interface CareerPlaybookSmokeEvidencePlaybook {
+  id: string;
+  status: CareerPlaybookPlaybookStatus;
+  completedAt?: string | null;
+  generatedBlocks: Partial<Record<CareerPlaybookBlockId, CareerPlaybookBlockState>>;
+  finalMarkdown?: string | null;
+}
+
+export interface CareerPlaybookSmokePdfEvidence {
+  contentType: string;
+  sizeBytes: number;
+  startsWithPdfHeader?: boolean;
+}
+
+export interface CareerPlaybookSmokeShareEvidence {
+  isPublic: boolean;
+  shareSlug?: string | null;
+  publicFetchOk?: boolean;
+}
+
+export interface CareerPlaybookSmokeCourseBridgeEvidence {
+  courseId?: string | null;
+  redirectUrl?: string | null;
+  sourceDocumentIds?: string[];
+}
+
+export interface CareerPlaybookSmokeEvidenceInput {
+  playbook: CareerPlaybookSmokeEvidencePlaybook;
+  pdf?: CareerPlaybookSmokePdfEvidence;
+  share?: CareerPlaybookSmokeShareEvidence;
+  courseBridge?: CareerPlaybookSmokeCourseBridgeEvidence;
+  requireSurfaces?: boolean;
+  requireCourseBridge?: boolean;
+}
+
+export interface CareerPlaybookSmokeEvidenceReport {
+  status: 'pass' | 'fail';
+  checks: CareerPlaybookSmokeEvidenceCheck[];
+}
+
+function hasText(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function summarizeEvidenceStatus(
+  checks: CareerPlaybookSmokeEvidenceCheck[]
+): CareerPlaybookSmokeEvidenceReport['status'] {
+  return checks.some(check => check.status === 'fail') ? 'fail' : 'pass';
+}
+
+function validateCompletedPlaybook(
+  playbook: CareerPlaybookSmokeEvidencePlaybook
+): CareerPlaybookSmokeEvidenceCheck {
+  if (playbook.status !== 'completed') {
+    return {
+      id: 'completed-playbook',
+      status: 'fail',
+      note: `Expected completed status; found ${playbook.status}.`,
+    };
+  }
+
+  if (!hasText(playbook.completedAt)) {
+    return {
+      id: 'completed-playbook',
+      status: 'fail',
+      note: 'Completed playbook is missing completedAt evidence.',
+    };
+  }
+
+  if (!hasText(playbook.finalMarkdown)) {
+    return {
+      id: 'completed-playbook',
+      status: 'fail',
+      note: 'Completed playbook is missing finalMarkdown evidence.',
+    };
+  }
+
+  return {
+    id: 'completed-playbook',
+    status: 'pass',
+    note: `Career Playbook ${playbook.id} is completed with final markdown.`,
+  };
+}
+
+function validateGeneratedBlocks(
+  generatedBlocks: Partial<Record<CareerPlaybookBlockId, CareerPlaybookBlockState>>
+): CareerPlaybookSmokeEvidenceCheck {
+  const missing = CAREER_PLAYBOOK_FINAL_BLOCK_ORDER.filter(blockId => {
+    const content = generatedBlocks[blockId]?.content;
+    return !hasText(content);
+  });
+
+  if (missing.length > 0) {
+    return {
+      id: 'generated-blocks',
+      status: 'fail',
+      note: `Missing generated block evidence: ${missing.join(', ')}.`,
+    };
+  }
+
+  return {
+    id: 'generated-blocks',
+    status: 'pass',
+    note: `All ${CAREER_PLAYBOOK_FINAL_BLOCK_ORDER.length} required blocks are present.`,
+  };
+}
+
+const TABLE_SEPARATOR_PATTERN = /^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$/;
+
+function isTableLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith('|') && trimmed.includes('|', 1);
+}
+
+function isNonEmptyTableRow(line: string): boolean {
+  return (
+    line
+      .split('|')
+      .map(cell => cell.trim())
+      .filter(Boolean).length > 0
+  );
+}
+
+function countMarkdownTableBodyRows(markdown: string): number {
+  const lines = markdown.split(/\r?\n/);
+  let total = 0;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!TABLE_SEPARATOR_PATTERN.test(lines[index])) continue;
+
+    let rowIndex = index + 1;
+    while (rowIndex < lines.length && isTableLine(lines[rowIndex])) {
+      if (!TABLE_SEPARATOR_PATTERN.test(lines[rowIndex]) && isNonEmptyTableRow(lines[rowIndex])) {
+        total += 1;
+      }
+      rowIndex += 1;
+    }
+  }
+
+  return total;
+}
+
+function countMarkdownListItems(markdown: string): number {
+  return markdown.split(/\r?\n/).filter(line => /^\s*(?:[-*+]|\d+[.)])\s+\S/.test(line)).length;
+}
+
+function countStructuredItems(markdown: string): number {
+  return Math.max(countMarkdownTableBodyRows(markdown), countMarkdownListItems(markdown));
+}
+
+function countMermaidDiagrams(markdown: string): number {
+  return markdown.match(/```mermaid[\s\S]*?```/gi)?.length ?? 0;
+}
+
+function validateDeterministicContent(
+  generatedBlocks: Partial<Record<CareerPlaybookBlockId, CareerPlaybookBlockState>>
+): CareerPlaybookSmokeEvidenceCheck {
+  const issues: string[] = [];
+  const antiGoals = countStructuredItems(generatedBlocks.block_2?.content ?? '');
+  const decisions = countStructuredItems(generatedBlocks.block_5?.content ?? '');
+  const failureModes = countStructuredItems(generatedBlocks.block_21?.content ?? '');
+  const dependenciesMermaid = countMermaidDiagrams(generatedBlocks.block_10?.content ?? '');
+  const careerMermaid = countMermaidDiagrams(generatedBlocks.block_11?.content ?? '');
+  const processMermaid = countMermaidDiagrams(generatedBlocks.block_16?.content ?? '');
+
+  if (antiGoals < 4) issues.push(`Expected block_2 to contain at least 4 anti-goals; found ${antiGoals}.`);
+  if (decisions < 4) issues.push(`Expected block_5 to contain at least 4 decisions; found ${decisions}.`);
+  if (failureModes < 3) {
+    issues.push(`Expected block_21 to contain at least 3 failure modes; found ${failureModes}.`);
+  }
+  if (dependenciesMermaid < 1) issues.push('Expected block_10 dependencies Mermaid coverage.');
+  if (careerMermaid < 1) issues.push('Expected block_11 career path Mermaid coverage.');
+  if (processMermaid < 1) issues.push('Expected block_16 main process Mermaid coverage.');
+
+  if (issues.length > 0) {
+    return {
+      id: 'deterministic-content',
+      status: 'fail',
+      note: issues.join(' '),
+    };
+  }
+
+  return {
+    id: 'deterministic-content',
+    status: 'pass',
+    note: 'Required Mermaid, anti-goal, decision-matrix, and failure-mode checks passed.',
+  };
+}
+
+function validatePdf(
+  pdf: CareerPlaybookSmokePdfEvidence | undefined,
+  requireSurfaces: boolean
+): CareerPlaybookSmokeEvidenceCheck {
+  if (!pdf) {
+    return {
+      id: 'pdf-export',
+      status: requireSurfaces ? 'fail' : 'skipped',
+      note: 'PDF export evidence was not supplied.',
+    };
+  }
+
+  if (pdf.contentType !== 'application/pdf' || pdf.sizeBytes <= 0 || !pdf.startsWithPdfHeader) {
+    return {
+      id: 'pdf-export',
+      status: 'fail',
+      note: 'PDF evidence must be application/pdf, non-empty, and start with a PDF header.',
+    };
+  }
+
+  return {
+    id: 'pdf-export',
+    status: 'pass',
+    note: `PDF export returned ${pdf.sizeBytes} bytes.`,
+  };
+}
+
+function validateShare(
+  share: CareerPlaybookSmokeShareEvidence | undefined,
+  requireSurfaces: boolean
+): CareerPlaybookSmokeEvidenceCheck {
+  if (!share) {
+    return {
+      id: 'public-share',
+      status: requireSurfaces ? 'fail' : 'skipped',
+      note: 'Public share evidence was not supplied.',
+    };
+  }
+
+  if (!share.isPublic || !hasText(share.shareSlug) || share.publicFetchOk !== true) {
+    return {
+      id: 'public-share',
+      status: 'fail',
+      note: 'Share evidence must include public=true, a share slug, and a successful public fetch.',
+    };
+  }
+
+  return {
+    id: 'public-share',
+    status: 'pass',
+    note: `Public share ${share.shareSlug} rendered successfully.`,
+  };
+}
+
+function validateCourseBridge(
+  courseBridge: CareerPlaybookSmokeCourseBridgeEvidence | undefined,
+  requireSurfaces: boolean
+): CareerPlaybookSmokeEvidenceCheck {
+  if (!courseBridge) {
+    return {
+      id: 'course-bridge',
+      status: requireSurfaces ? 'fail' : 'skipped',
+      note: 'Course bridge evidence was not supplied.',
+    };
+  }
+
+  if (
+    !hasText(courseBridge.courseId) ||
+    !hasText(courseBridge.redirectUrl) ||
+    !courseBridge.sourceDocumentIds ||
+    courseBridge.sourceDocumentIds.length === 0
+  ) {
+    return {
+      id: 'course-bridge',
+      status: 'fail',
+      note: 'Course bridge evidence must include courseId, redirectUrl, and source document IDs.',
+    };
+  }
+
+  return {
+    id: 'course-bridge',
+    status: 'pass',
+    note: `Course bridge created ${courseBridge.courseId} with ${courseBridge.sourceDocumentIds.length} source document(s).`,
+  };
+}
+
+export function validateCareerPlaybookSmokeEvidence(
+  input: CareerPlaybookSmokeEvidenceInput
+): CareerPlaybookSmokeEvidenceReport {
+  const requireSurfaces = input.requireSurfaces ?? true;
+  const requireCourseBridge = input.requireCourseBridge ?? requireSurfaces;
+  const checks: CareerPlaybookSmokeEvidenceCheck[] = [
+    validateCompletedPlaybook(input.playbook),
+    validateGeneratedBlocks(input.playbook.generatedBlocks),
+    validateDeterministicContent(input.playbook.generatedBlocks),
+    validatePdf(input.pdf, requireSurfaces),
+    validateShare(input.share, requireSurfaces),
+    validateCourseBridge(input.courseBridge, requireCourseBridge),
+  ];
+
+  return {
+    status: summarizeEvidenceStatus(checks),
+    checks,
+  };
+}

--- a/packages/course-gen-platform/tests/unit/smoke/career-playbook-live-smoke.test.ts
+++ b/packages/course-gen-platform/tests/unit/smoke/career-playbook-live-smoke.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CareerPlaybookBlockId, CareerPlaybookBlockState } from '@megacampus/shared-types';
+
+import {
+  buildCareerPlaybookCleanupManifest,
+  buildCareerPlaybookLiveSmokePlan,
+  runCareerPlaybookLiveSmoke,
+  type CareerPlaybookLiveSmokeClient,
+} from '@/smoke/career-playbook-live-smoke';
+import { validateCareerPlaybookSmokeEvidence } from '@/smoke/career-playbook-validation';
+
+function generatedBlock(content: string): CareerPlaybookBlockState {
+  return {
+    content,
+    status: 'generated',
+    attempt: 1,
+    generated_at: '2026-05-21T00:00:00.000Z',
+  };
+}
+
+function buildCompleteBlocks(): Record<CareerPlaybookBlockId, CareerPlaybookBlockState> {
+  const blocks = Object.fromEntries(
+    [
+      'header',
+      ...Array.from({ length: 26 }, (_, index) => `block_${index + 1}`),
+    ].map(blockId => [
+      blockId,
+      generatedBlock(`## ${blockId}\n\nUseful smoke evidence for ${blockId}.`),
+    ])
+  ) as Record<CareerPlaybookBlockId, CareerPlaybookBlockState>;
+
+  blocks.block_2 = generatedBlock(`## 2. Anti-goals
+
+| Anti-goal | Owner |
+| --- | --- |
+| No enterprise discounting | Sales Ops |
+| No product roadmap ownership | Product |
+| No customer success handoff gaps | CS |
+| No unsupported legal promises | Legal |`);
+
+  blocks.block_5 = generatedBlock(`## 5. Decision Matrix
+
+| Decision | Autonomy | Action |
+| --- | --- | --- |
+| Prioritize account tier | Own | Decide |
+| Escalate deal risk | Consult | Align |
+| Approve custom terms | Recommend | Escalate |
+| Change territory focus | Consult | Propose |`);
+
+  blocks.block_10 = generatedBlock(`## 10. Dependencies
+
+\`\`\`mermaid
+flowchart LR
+  Sales --> Product
+\`\`\``);
+
+  blocks.block_11 = generatedBlock(`## 11. Career Path
+
+\`\`\`mermaid
+flowchart LR
+  SDR --> AE --> Lead
+\`\`\``);
+
+  blocks.block_16 = generatedBlock(`## 16. Main Process
+
+\`\`\`mermaid
+flowchart TD
+  Qualify --> Close
+\`\`\``);
+
+  blocks.block_21 = generatedBlock(`## 21. Failure Modes
+
+- Pipeline quality collapses.
+- Forecast hygiene drifts.
+- Handoff quality drops.`);
+
+  return blocks;
+}
+
+function buildLiveSmokeClient(
+  overrides: Partial<CareerPlaybookLiveSmokeClient> = {}
+): CareerPlaybookLiveSmokeClient {
+  return {
+    startSession: vi.fn().mockResolvedValue({
+      playbookId: '33333333-3333-3333-3333-333333333333',
+      status: 'answering_fixed',
+    }),
+    submitAnswer: vi.fn().mockResolvedValue({ ok: true }),
+    requestFollowups: vi.fn().mockResolvedValue({
+      questions: [],
+      completeness_score: 0.85,
+      stop_recommendation: 'ready_to_generate',
+    }),
+    approveAndGenerate: vi.fn().mockResolvedValue({
+      playbookId: '33333333-3333-3333-3333-333333333333',
+      status: 'generating',
+    }),
+    getStatus: vi.fn().mockResolvedValue({
+      playbookId: '33333333-3333-3333-3333-333333333333',
+      status: 'completed',
+      progress: 100,
+    }),
+    getLibraryDetail: vi.fn().mockResolvedValue({
+      id: '33333333-3333-3333-3333-333333333333',
+      status: 'completed',
+      finalMarkdown: '## final\n\n```mermaid\nflowchart LR\nA-->B\n```',
+      generatedBlocks: buildCompleteBlocks(),
+      completedAt: '2026-05-21T00:00:00.000Z',
+    }),
+    exportPdf: vi.fn().mockResolvedValue({
+      pdfBase64: Buffer.from('%PDF smoke').toString('base64'),
+      contentType: 'application/pdf',
+      sizeBytes: 1024,
+    }),
+    toggleShare: vi.fn().mockResolvedValue({
+      shareSlug: 'cp-live-smoke',
+      isPublic: true,
+    }),
+    getPublicShare: vi.fn().mockResolvedValue({ ok: true }),
+    createCourseFromPlaybook: vi.fn().mockResolvedValue({
+      courseId: '44444444-4444-4444-4444-444444444444',
+      redirectUrl: '/courses/demo/sales-manager-b2b/generating',
+      sourceDocumentIds: ['55555555-5555-5555-5555-555555555555'],
+    }),
+    ...overrides,
+  };
+}
+
+describe('Career Playbook live smoke gates', () => {
+  it('keeps plan mode non-mutating and reports missing live-smoke gates', async () => {
+    const client = {
+      startSession: vi.fn(),
+      submitAnswer: vi.fn(),
+      requestFollowups: vi.fn(),
+      approveAndGenerate: vi.fn(),
+      getStatus: vi.fn(),
+      getLibraryDetail: vi.fn(),
+      exportPdf: vi.fn(),
+      toggleShare: vi.fn(),
+      getPublicShare: vi.fn(),
+      createCourseFromPlaybook: vi.fn(),
+    };
+
+    const report = await runCareerPlaybookLiveSmoke(
+      {
+        mode: 'plan',
+        targetEnvironment: 'staging',
+        env: {
+          NODE_ENV: 'production',
+          BULLMQ_QUEUE_NAME: 'career-playbook-smoke-20260521',
+        },
+      },
+      { client }
+    );
+
+    expect(report.status).toBe('blocked');
+    expect(report.mutates).toBe(false);
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'mode',
+        status: 'skipped',
+        mutates: false,
+      })
+    );
+    expect(report.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'auth-token',
+        status: 'blocked',
+      })
+    );
+    expect(client.startSession).not.toHaveBeenCalled();
+    expect(client.approveAndGenerate).not.toHaveBeenCalled();
+  });
+
+  it('blocks staging mutation smoke without token, expected fixture IDs, cleanup scope, and budget', () => {
+    const plan = buildCareerPlaybookLiveSmokePlan({
+      mode: 'mutation-smoke',
+      targetEnvironment: 'staging',
+      env: {
+        NODE_ENV: 'production',
+        BULLMQ_QUEUE_NAME: 'career-playbook-smoke-20260521',
+      },
+      confirmLiveMutation: true,
+    });
+
+    expect(plan.status).toBe('blocked');
+    expect(plan.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'auth-token', status: 'blocked' }),
+        expect.objectContaining({ id: 'expected-user-id', status: 'blocked' }),
+        expect.objectContaining({ id: 'expected-organization-id', status: 'blocked' }),
+        expect.objectContaining({ id: 'cleanup-scope', status: 'blocked' }),
+        expect.objectContaining({ id: 'max-cost-usd', status: 'blocked' }),
+      ])
+    );
+  });
+
+  it('rejects the shared default queue in staging mutation mode', () => {
+    const plan = buildCareerPlaybookLiveSmokePlan({
+      mode: 'mutation-smoke',
+      targetEnvironment: 'staging',
+      token: 'token-value',
+      expectedUserId: '11111111-1111-1111-1111-111111111111',
+      expectedOrganizationId: '22222222-2222-2222-2222-222222222222',
+      cleanupScope: 'playbook-and-course',
+      maxCostUsd: 3,
+      confirmLiveMutation: true,
+      env: {
+        NODE_ENV: 'production',
+        BULLMQ_QUEUE_NAME: 'course-generation',
+      },
+    });
+
+    expect(plan.status).toBe('blocked');
+    expect(plan.checks).toContainEqual(
+      expect.objectContaining({
+        id: 'dedicated-queue',
+        status: 'blocked',
+        note: expect.stringContaining('dedicated non-default'),
+      })
+    );
+  });
+});
+
+describe('Career Playbook live smoke mutation report', () => {
+  it('keeps course bridge optional while recording exact fixture cleanup IDs from env', async () => {
+    const report = await runCareerPlaybookLiveSmoke(
+      {
+        mode: 'mutation-smoke',
+        targetEnvironment: 'staging',
+        trpcUrl: 'https://staging.example.test/trpc',
+        cleanupScope: 'playbook-only',
+        maxCostUsd: 3,
+        confirmLiveMutation: true,
+        env: {
+          TOKEN: 'secret-token',
+          BULLMQ_QUEUE_NAME: 'career-playbook-smoke-20260521',
+          CAREER_PLAYBOOK_SMOKE_USER_ID: '11111111-1111-1111-1111-111111111111',
+          CAREER_PLAYBOOK_SMOKE_ORGANIZATION_ID: '22222222-2222-2222-2222-222222222222',
+        },
+      },
+      { client: buildLiveSmokeClient() }
+    );
+
+    expect(report.status).toBe('pass');
+    expect(report.evidence?.status).toBe('pass');
+    expect(report.evidence?.checks).toContainEqual(
+      expect.objectContaining({ id: 'course-bridge', status: 'skipped' })
+    );
+    expect(report.cleanupManifest?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'auth_user', id: '11111111-1111-1111-1111-111111111111' }),
+        expect.objectContaining({
+          type: 'organization',
+          id: '22222222-2222-2222-2222-222222222222',
+        }),
+      ])
+    );
+  });
+
+  it('fails the live smoke report when collected PDF evidence is invalid', async () => {
+    const client = buildLiveSmokeClient({
+      exportPdf: vi.fn().mockResolvedValue({
+        pdfBase64: Buffer.from('not a pdf').toString('base64'),
+        contentType: 'application/pdf',
+        sizeBytes: 1024,
+      }),
+    });
+
+    const report = await runCareerPlaybookLiveSmoke(
+      {
+        mode: 'mutation-smoke',
+        targetEnvironment: 'staging',
+        trpcUrl: 'https://staging.example.test/trpc',
+        expectedUserId: '11111111-1111-1111-1111-111111111111',
+        expectedOrganizationId: '22222222-2222-2222-2222-222222222222',
+        cleanupScope: 'playbook-only',
+        maxCostUsd: 3,
+        confirmLiveMutation: true,
+        env: {
+          TOKEN: 'secret-token',
+          BULLMQ_QUEUE_NAME: 'career-playbook-smoke-20260521',
+        },
+      },
+      { client }
+    );
+
+    expect(report.status).toBe('fail');
+    expect(report.evidence?.checks).toContainEqual(
+      expect.objectContaining({ id: 'pdf-export', status: 'fail' })
+    );
+  });
+});
+
+describe('Career Playbook live smoke evidence validation', () => {
+  it('passes complete generated playbook, PDF, share, and course bridge evidence', () => {
+    const report = validateCareerPlaybookSmokeEvidence({
+      playbook: {
+        id: '33333333-3333-3333-3333-333333333333',
+        status: 'completed',
+        completedAt: '2026-05-21T00:00:00.000Z',
+        generatedBlocks: buildCompleteBlocks(),
+        finalMarkdown: '## final\n\n```mermaid\nflowchart LR\nA-->B\n```',
+      },
+      pdf: {
+        contentType: 'application/pdf',
+        sizeBytes: 1024,
+        startsWithPdfHeader: true,
+      },
+      share: {
+        isPublic: true,
+        shareSlug: 'cp-live-smoke',
+        publicFetchOk: true,
+      },
+      courseBridge: {
+        courseId: '44444444-4444-4444-4444-444444444444',
+        redirectUrl: '/courses/demo/sales-manager-b2b/generating',
+        sourceDocumentIds: ['55555555-5555-5555-5555-555555555555'],
+      },
+    });
+
+    expect(report.status).toBe('pass');
+    expect(report.checks.every(check => check.status === 'pass')).toBe(true);
+  });
+
+  it('fails when generated blocks are incomplete or deterministic thresholds are missing', () => {
+    const blocks = buildCompleteBlocks();
+    delete (blocks as Partial<Record<CareerPlaybookBlockId, CareerPlaybookBlockState>>).block_26;
+    blocks.block_2 = generatedBlock('## 2. Anti-goals\n\n- One item only');
+
+    const report = validateCareerPlaybookSmokeEvidence({
+      playbook: {
+        id: '33333333-3333-3333-3333-333333333333',
+        status: 'completed',
+        completedAt: '2026-05-21T00:00:00.000Z',
+        generatedBlocks: blocks,
+        finalMarkdown: '## final',
+      },
+    });
+
+    expect(report.status).toBe('fail');
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'generated-blocks', status: 'fail' }),
+        expect.objectContaining({ id: 'deterministic-content', status: 'fail' }),
+      ])
+    );
+  });
+});
+
+describe('Career Playbook live smoke cleanup manifest', () => {
+  it('records exact cleanup targets without leaking secrets', () => {
+    const manifest = buildCareerPlaybookCleanupManifest({
+      runId: 'career-playbook-smoke-20260521',
+      targetEnvironment: 'staging',
+      queueName: 'career-playbook-smoke-20260521',
+      token: 'super-secret-token',
+      expectedUserId: '11111111-1111-1111-1111-111111111111',
+      expectedOrganizationId: '22222222-2222-2222-2222-222222222222',
+      playbookId: '33333333-3333-3333-3333-333333333333',
+      careerPlaybookJobId: 'career-playbook:33333333-3333-3333-3333-333333333333',
+      shareSlug: 'cp-live-smoke',
+      courseId: '44444444-4444-4444-4444-444444444444',
+      sourceDocumentIds: ['55555555-5555-5555-5555-555555555555'],
+      uploadPaths: [
+        'uploads/22222222-2222-2222-2222-222222222222/44444444-4444-4444-4444-444444444444/demo.md',
+      ],
+    });
+
+    const serialized = JSON.stringify(manifest);
+
+    expect(manifest.mutates).toBe(false);
+    expect(manifest.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'career_playbook', id: '33333333-3333-3333-3333-333333333333' }),
+        expect.objectContaining({ type: 'bullmq_job', id: 'career-playbook:33333333-3333-3333-3333-333333333333' }),
+        expect.objectContaining({ type: 'course', id: '44444444-4444-4444-4444-444444444444' }),
+        expect.objectContaining({ type: 'upload_path', id: expect.stringContaining('demo.md') }),
+      ])
+    );
+    expect(serialized).not.toContain('super-secret-token');
+  });
+});


### PR DESCRIPTION
## Summary
- add `smoke:career-playbook:live` gated runner for Career Playbook live staging smoke
- keep default `plan` mode non-mutating and require explicit gates for `mutation-smoke`
- validate generated playbook evidence and emit exact dry-run cleanup manifest
- update Career Playbook runtime docs, stage summary, handoff, and artifact

## Safety
- no live mutation smoke was run
- no worker was started, Redis job enqueued, Supabase row created, cleanup action run, or LLM called
- no billing/payment scope added

## Verification
- `SUPABASE_URL=http://127.0.0.1:54321 SUPABASE_SERVICE_KEY=test-service-key SUPABASE_ANON_KEY=test-anon-key REDIS_URL=redis://127.0.0.1:6379 NODE_ENV=test pnpm --dir packages/course-gen-platform exec vitest run --config vitest.config.unit.ts tests/unit/smoke/career-playbook-preflight.test.ts tests/unit/smoke/career-playbook-live-smoke.test.ts`
- `pnpm --filter @megacampus/course-gen-platform type-check`
- `pnpm type-check`
- `pnpm lint` (existing warnings only)
- `SUPABASE_SERVICE_ROLE_KEY=test-service-role NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon pnpm build` (existing Next/Supabase warnings only)
- `git diff --check`
- `python3 scripts/orchestration/validate_artifact.py .codex/stages/mc2-db696.11/artifacts/mc2-db696.11.5-live-runner.md`
- `python3 scripts/orchestration/check_stage_ready.py mc2-db696.11`
- `scripts/orchestration/run_process_verification.sh`

## Beads
- `mc2-db696.11.5` remains in progress until actual live staging mutation smoke has disposable fixtures, queue alignment, cleanup execution authorization, and numeric API budget.