### PR TITLE
fix(career-playbook): prevent landing demo overlap

### DIFF
--- a/packages/web/app/[locale]/career-playbook/page-client.tsx
+++ b/packages/web/app/[locale]/career-playbook/page-client.tsx
@@ -21,7 +21,7 @@ import { Link } from '@/src/i18n/navigation'
 
 const methodologyIds = ['netflix', 'amazon', 'toyota', 'spotify', 'bridgewater'] as const
 const blockGroupIds = ['foundation', 'operations', 'people', 'growth', 'system', 'wrap'] as const
-const demoSectionIds = ['decisions', 'mission', 'kpi'] as const
+const demoSectionIds = ['mission', 'decisions', 'kpi'] as const
 const faqItemIds = ['0', '1', '2'] as const
 
 type MethodologyId = (typeof methodologyIds)[number]

--- a/packages/web/components/career-playbook/methodology/InteractiveDemo.tsx
+++ b/packages/web/components/career-playbook/methodology/InteractiveDemo.tsx
@@ -55,8 +55,8 @@ export function InteractiveDemo({
           <p className="mt-5 text-base leading-7 text-slate-300">{subtitle}</p>
         </div>
 
-        <div className="grid gap-5 lg:grid-cols-[18rem_minmax(0,1fr)]">
-          <div className="grid content-start gap-2">
+        <div className="grid gap-5 xl:grid-cols-[minmax(14rem,18rem)_minmax(0,1fr)]">
+          <div className="grid min-w-0 content-start gap-2">
             {sections.map((section) => {
               const isActive = section.id === activeSection.id
 
@@ -66,19 +66,21 @@ export function InteractiveDemo({
                   type="button"
                   variant="ghost"
                   className={cn(
-                    'h-auto min-h-16 justify-start rounded-lg border p-4 text-left',
+                    'h-auto min-h-16 w-full min-w-0 justify-start rounded-lg border p-4 text-left whitespace-normal',
                     'border-white/10 bg-white/5 text-slate-200 hover:border-amber-300/40 hover:bg-white/10',
                     isActive && 'border-amber-300/60 bg-amber-300/15 text-white'
                   )}
                   onClick={() => setActiveSectionId(section.id)}
                 >
-                  <span className="flex items-start gap-3">
+                  <span className="flex min-w-0 items-start gap-3">
                     <FileText
                       className="mt-0.5 h-4 w-4 shrink-0 text-amber-200"
                       aria-hidden="true"
                     />
-                    <span>
-                      <span className="block text-sm font-semibold">{section.title}</span>
+                    <span className="min-w-0">
+                      <span className="block text-sm leading-5 font-semibold break-words">
+                        {section.title}
+                      </span>
                       <span className="mt-1 block text-xs text-slate-400">
                         {section.blockLabel}
                       </span>
@@ -89,8 +91,8 @@ export function InteractiveDemo({
             })}
           </div>
 
-          <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem]">
-            <article className="min-h-[26rem] rounded-lg border border-white/10 bg-white/95 p-6 text-slate-950 shadow-2xl md:p-8">
+          <div className="grid min-w-0 gap-5 lg:grid-cols-[minmax(0,1fr)_18rem]">
+            <article className="min-h-[26rem] min-w-0 rounded-lg border border-white/10 bg-white/95 p-6 text-slate-950 shadow-2xl md:p-8">
               <div className="mb-6 flex items-center justify-between gap-4 border-b border-slate-200 pb-4">
                 <div>
                   <p className="text-xs font-semibold text-slate-500">{previewTitle}</p>
@@ -123,7 +125,7 @@ export function InteractiveDemo({
               </div>
             </article>
 
-            <aside className="rounded-lg border border-amber-300/20 bg-amber-300/10 p-5">
+            <aside className="min-w-0 rounded-lg border border-amber-300/20 bg-amber-300/10 p-5">
               <p className="text-sm font-semibold text-amber-100">{activeSection.blockLabel}</p>
               <p className="mt-4 text-sm leading-6 text-slate-200">{activeSection.annotation}</p>
             </aside>

--- a/packages/web/tests/unit/components/career-playbook/landing-page.test.tsx
+++ b/packages/web/tests/unit/components/career-playbook/landing-page.test.tsx
@@ -137,8 +137,19 @@ describe('CareerPlaybookLandingPageClient', () => {
 
     expect(screen.getAllByTestId('career-playbook-methodology-card')).toHaveLength(5)
     expect(screen.getAllByTestId('career-playbook-block-chip')).toHaveLength(26)
-    expect(screen.getByRole('button', { name: /decision matrix/i })).toBeInTheDocument()
-    expect(screen.getByText(/small discounts can move quickly/i)).toBeInTheDocument()
+    const demoButtons = screen.getAllByRole('button').filter((button) => {
+      return /mission and key results|decision matrix|kpi and counter-metrics/i.test(
+        button.textContent ?? ''
+      )
+    })
+    expect(demoButtons.map((button) => button.textContent)).toEqual([
+      expect.stringMatching(/Mission and key results.*Block 1/i),
+      expect.stringMatching(/Decision matrix.*Block 5/i),
+      expect.stringMatching(/KPI and counter-metrics.*Block 6/i),
+    ])
+    expect(
+      screen.getByText(/the role turns b2b pipeline into predictable revenue/i)
+    ).toBeInTheDocument()
   })
 
   it('localizes the block map, selected-block label, and demo chrome for Russian', () => {

--- a/packages/web/tests/unit/components/career-playbook/methodology.test.tsx
+++ b/packages/web/tests/unit/components/career-playbook/methodology.test.tsx
@@ -142,4 +142,31 @@ describe('InteractiveDemo', () => {
     expect(screen.getByText(/discounts above twenty percent/i)).toBeInTheDocument()
     expect(screen.getByText(/visible guardrails/i)).toBeInTheDocument()
   })
+
+  it('allows long selector labels to wrap inside their column', () => {
+    render(
+      <InteractiveDemo
+        eyebrow="Interactive demo"
+        title="Annotated B2B sales Role Guide preview"
+        subtitle="Inspect the generated document."
+        previewTitle="B2B Sales Role Guide"
+        sections={[
+          ...demoSections,
+          {
+            id: 'metrics',
+            title: 'Very long performance indicators and control metrics label',
+            excerpt: 'Metrics stay readable.',
+            annotation: 'Long labels should not expand the selector column.',
+            blockLabel: 'Block 6',
+          },
+        ]}
+      />
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: /very long performance indicators and control metrics label/i,
+      })
+    ).toHaveClass('w-full', 'min-w-0', 'whitespace-normal')
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes the Career Playbook landing demo selector so long Russian labels wrap inside the left column instead of overlapping the central document preview.
- Changes the demo sequence from block 5 → 1 → 6 to the logical block 1 → 5 → 6 order.
- Adds regression coverage for demo order and long selector labels.

## Verification
- `pnpm --filter @megacampus/web exec vitest run tests/unit/components/career-playbook/landing-page.test.tsx tests/unit/components/career-playbook/methodology.test.tsx`
- `pnpm --filter @megacampus/web lint`
- `pnpm --filter @megacampus/web type-check`
- `SUPABASE_SERVICE_ROLE_KEY=test-service-role NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=test-anon pnpm --filter @megacampus/web build`

## Notes
- Local browser smoke was blocked by the existing localhost default-locale middleware redirect loop. Dev smoke should be run after merge/deploy, as the deployed Dev URL does not hit that local-only loop.
