### PR TITLE
fix(ci): restrict rollback to deploy failures

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -713,7 +713,10 @@ jobs:
     name: Rollback
     runs-on: ubuntu-latest
     needs: [deploy]
-    if: failure()
+    # Roll back only after an actual production deploy job failure.
+    # A broad failure() condition also fires on unrelated CI/setup failures when
+    # deploy is skipped, which can trigger a misleading rollback attempt.
+    if: ${{ failure() && needs.deploy.result == 'failure' }}
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Summary
- restrict the rollback job to run only when the production deploy job itself fails
- prevent misleading rollback attempts after unrelated CI/setup failures when deploy is skipped
- document the reason inline in the workflow

## Verification
- python YAML parse and rollback condition assertion
- actionlint on .github/workflows/ci-cd.yml

## Notes
- GitHub Actions currently has an external Actions/Pages incident affecting auth/action downloads, so live PR checks may fail for reasons unrelated to this patch.

Beads: mc2-db696.36.8